### PR TITLE
Add email api endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ruby-pardot.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,22 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.0)
+    ruby-pardot (1.0.1)
       crack
       httparty
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    crack (0.3.2)
+    crack (0.4.1)
+      safe_yaml (~> 0.9.0)
     diff-lcs (1.1.2)
     fakeweb (1.3.0)
-    httparty (0.10.2)
-      multi_json (~> 1.0)
+    httparty (0.12.0)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
-    multi_json (1.6.1)
-    multi_xml (0.5.3)
+    json (1.8.1)
+    multi_xml (0.5.5)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -24,6 +25,7 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
+    safe_yaml (0.9.7)
 
 PLATFORMS
   ruby

--- a/lib/pardot/authentication.rb
+++ b/lib/pardot/authentication.rb
@@ -2,8 +2,8 @@ module Pardot
   module Authentication
     
     def authenticate
-      resp = post "login", nil, :email => @email, :password => @password, :user_key => @user_key
-      @api_key = resp["api_key"]
+      resp = post 'login', nil, :email => @email, :password => @password, :user_key => @user_key
+      @api_key = resp['api_key']
     end
     
     def authenticated?

--- a/lib/pardot/client.rb
+++ b/lib/pardot/client.rb
@@ -4,8 +4,7 @@ module Pardot
     
     include HTTParty
     base_uri 'https://pi.pardot.com'
-    format :xml
-    
+
     include Authentication
     include Http
 
@@ -24,9 +23,9 @@ module Pardot
       @password = password
       @user_key = user_key
       
-      @format = "simple"
+      @output = 'simple'
+      @format = 'json'
     end
-    
-    
+
   end
 end

--- a/lib/pardot/client.rb
+++ b/lib/pardot/client.rb
@@ -8,6 +8,7 @@ module Pardot
     include Authentication
     include Http
 
+    include Objects::Emails
     include Objects::Lists
     include Objects::Opportunities
     include Objects::Prospects

--- a/lib/pardot/error.rb
+++ b/lib/pardot/error.rb
@@ -6,14 +6,15 @@ module Pardot
   class ResponseError < Error
     def initialize(res)
       @res = res
+      @attributes = {}
     end
 
     def to_s
-      @res["__content__"]
+      @res['__content__']
     end
 
     def code
-      @res["code"].to_i
+      @res['code'].to_i
     end
 
     def inspect

--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -16,7 +16,7 @@ module Pardot
     def post object, path, params = {}, num_retries = 0
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params)
+      check_response self.class.post(full_path, :body => params)
       
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
@@ -36,35 +36,34 @@ module Pardot
     end
     
     def smooth_params object, params
-      return if object == "login"
+      return if object == 'login'
       
       authenticate unless authenticated?
-      params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
+      params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format, :output => @output
     end
     
     def check_response http_response
-      rsp = http_response["rsp"]
-      
-      error = rsp["err"] if rsp
-      error ||= "Unknown Failure: #{rsp.inspect}" if rsp && rsp["stat"] == "fail"
+      rsp = http_response['rsp'] || http_response || {}
+      error = rsp['err']
+      status = ( rsp['@attributes'] && rsp['@attributes']['stat'] ) || rsp['stat']
+      error ||= "Unknown Failure: #{rsp.inspect}" if status == 'fail'
       content = error['__content__'] if error.is_a?(Hash)
       
-      if [error, content].include?("Invalid API key or user key") && @api_key
+      if [error, content].include?('Invalid API key or user key') && @api_key
         raise ExpiredApiKeyError.new @api_key
       end
       
       raise ResponseError.new error if error
-      
+
       rsp
     end
     
     def fullpath object, path, version = 3
-      full = File.join("/api", object, "version", version.to_s)
+      full = File.join('/api', object, 'version', version.to_s)
       unless path.nil?
         full = File.join(full, path)
       end
       full
     end
-    
   end
 end

--- a/lib/pardot/objects/base_object.rb
+++ b/lib/pardot/objects/base_object.rb
@@ -1,0 +1,28 @@
+module Pardot
+  module Objects
+    class BaseObject
+
+      def initialize client
+        @client = client
+      end
+
+      def query params
+        result = get '/do/query', params, nil
+        result['total_results'] = result['total_results'].to_i if result['total_results']
+        result
+      end
+
+      protected
+
+      def get path, params = {}, result = self.class::OBJECT_NAME
+        response = @client.get self.class::OBJECT_NAME, path, params
+        result ? response[result] : response
+      end
+
+      def post path, params = {}, result = self.class::OBJECT_NAME
+        response = @client.post self.class::OBJECT_NAME, path, params
+        result ? response[result] : response
+      end
+    end
+  end
+end

--- a/lib/pardot/objects/emails.rb
+++ b/lib/pardot/objects/emails.rb
@@ -1,0 +1,35 @@
+module Pardot
+  module Objects
+    module Emails
+      
+      def emails
+        @emails ||= Emails.new self
+      end
+      
+      class Emails < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'email'
+
+        # See: http://developer.pardot.com/kb/api-version-3/reading-emails for valid params
+        def read_by_id id, params = {}
+          get "/do/read/id/#{id}", params
+        end
+
+        # See: http://developer.pardot.com/kb/api-version-3/sending-one-to-one-emails for valid params
+        def send_by_id prospect_id, params = {}
+          post "/do/send/prospect_id/#{prospect_id}", params
+          # campaign_id, (email_template_id OR (text_content, name, subject, & ((from_email & from_name) OR from_user_id))
+        end
+
+        # See: http://developer.pardot.com/kb/api-version-3/sending-one-to-one-emails for valid params
+        def send_by_email prospect_email, params = {}
+          post "/do/send/prospect_email/#{prospect_email}", params
+        end
+
+        # See: http://developer.pardot.com/kb/api-version-3/sending-list-emails for valid params
+        def send_to_lists campaign_id, list_ids, params = {}
+          post 'do/send', params.merge(:list_ids => [*list_ids], :campaign_id => campaign_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/pardot/objects/lists.rb
+++ b/lib/pardot/objects/lists.rb
@@ -1,50 +1,22 @@
 module Pardot
   module Objects
-    
     module Lists
       
       def lists
         @lists ||= Lists.new self
       end
       
-      class Lists
-        
-        def initialize client
-          @client = client
-        end
-        
+      class Lists < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'list'
+
         def create id, params = {}
-          post "/do/create", params
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
+          post '/do/create', params
         end
         
         def read_by_id id, params = {}
           get "/do/read/id/#{id}", params
         end
-        
-        def update id, params = {}
-          post "/do/update/#{id}"
-        end
-        
-        protected
-        
-        def get path, params = {}, result = "list"
-          response = @client.get "list", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "list"
-          response = @client.post "list", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/opportunities.rb
+++ b/lib/pardot/objects/opportunities.rb
@@ -1,23 +1,13 @@
 module Pardot
   module Objects
-    
     module Opportunities
-      
+
       def opportunities
         @opportunities ||= Opportunities.new self
       end
       
-      class Opportunities
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
+      class Opportunities < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'opportunity'
         
         def create_by_email email, params = {}
           post "/do/create/prospect_email/#{email}", params
@@ -34,21 +24,7 @@ module Pardot
         def update_by_id id, params = {}
           post "/do/update/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "opportunity"
-          response = @client.get "opportunity", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "opportunity"
-          response = @client.post "opportunity", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/prospects.rb
+++ b/lib/pardot/objects/prospects.rb
@@ -6,18 +6,9 @@ module Pardot
         @prospects ||= Prospects.new self
       end
       
-      class Prospects
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query search_criteria
-          result = get "/do/query", search_criteria, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
-        
+      class Prospects < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'prospect'
+
         def assign_by_email email, params
           post "/do/assign/email/#{email}", params
         end
@@ -53,21 +44,7 @@ module Pardot
         def upsert_by_id id, params = {}
           post "/do/upsert/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "prospect"
-          response = @client.get "prospect", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "prospect"
-          response = @client.post "prospect", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/users.rb
+++ b/lib/pardot/objects/users.rb
@@ -6,17 +6,8 @@ module Pardot
         @users ||= Users.new self
       end
       
-      class Users
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
+      class Users < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'user'
         
         def read_by_email email, params = {}
           post "/do/read/email/#{email}", params
@@ -25,21 +16,7 @@ module Pardot
         def read_by_id id, params = {}
           post "/do/read/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "user"
-          response = @client.get "user", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "user"
-          response = @client.post "user", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/visitor_activities.rb
+++ b/lib/pardot/objects/visitor_activities.rb
@@ -6,36 +6,13 @@ module Pardot
         @visitor_activities ||= VisitorActivities.new self
       end
       
-      class VisitorActivities
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
+      class VisitorActivities < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'visitorActivity'
         
         def read id, params = {}
           post "/do/read/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "visitorActivity"
-          response = @client.get "visitorActivity", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "visitorActivity"
-          response = @client.post "visitorActivity", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/visitors.rb
+++ b/lib/pardot/objects/visitors.rb
@@ -6,17 +6,8 @@ module Pardot
         @visitors ||= Visitors.new self
       end
       
-      class Visitors
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
+      class Visitors < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'visitor'
         
         def assign id, params = {}
           post "/do/assign/id/#{id}", params
@@ -25,21 +16,7 @@ module Pardot
         def read id, params = {}
           post "/do/read/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "visitor"
-          response = @client.get "visitor", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "visitor"
-          response = @client.post "visitor", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/objects/visits.rb
+++ b/lib/pardot/objects/visits.rb
@@ -6,36 +6,13 @@ module Pardot
         @visits ||= Visits.new self
       end
       
-      class Visits
-        
-        def initialize client
-          @client = client
-        end
-        
-        def query params
-          result = get "/do/query", params, "result"
-          result["total_results"] = result["total_results"].to_i if result["total_results"]
-          result
-        end
+      class Visits < ::Pardot::Objects::BaseObject
+        OBJECT_NAME = 'visit'
         
         def read id, params = {}
           post "/do/read/id/#{id}", params
         end
-        
-        protected
-        
-        def get path, params = {}, result = "visit"
-          response = @client.get "visit", path, params
-          result ? response[result] : response
-        end
-        
-        def post path, params = {}, result = "visit"
-          response = @client.post "visit", path, params
-          result ? response[result] : response
-        end
-        
       end
-      
     end
   end
 end

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.0.1"
+  VERSION = '1.0.1'
 end

--- a/lib/ruby-pardot.rb
+++ b/lib/ruby-pardot.rb
@@ -6,6 +6,7 @@ require 'pardot/http'
 require 'pardot/error'
 require 'pardot/authentication'
 
+require 'pardot/objects/base_object'
 require 'pardot/objects/lists'
 require 'pardot/objects/opportunities'
 require 'pardot/objects/prospects'

--- a/lib/ruby-pardot.rb
+++ b/lib/ruby-pardot.rb
@@ -7,6 +7,7 @@ require 'pardot/error'
 require 'pardot/authentication'
 
 require 'pardot/objects/base_object'
+require 'pardot/objects/emails'
 require 'pardot/objects/lists'
 require 'pardot/objects/opportunities'
 require 'pardot/objects/prospects'

--- a/spec/pardot/authentication_spec.rb
+++ b/spec/pardot/authentication_spec.rb
@@ -11,7 +11,7 @@ describe Pardot::Authentication do
     before do
       @client = create_client
       
-      fake_post "/api/login/version/3?email=user%40test.com&password=foo&user_key=bar",
+      fake_post "/api/login/version/3",
                 %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">\n   <api_key>my_api_key</api_key>\n</rsp>\n)
     end
     

--- a/spec/pardot/error_spec.rb
+++ b/spec/pardot/error_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 describe Pardot::ResponseError do
   before do
     @res = {
-      "code" => "9",
-      "__content__" => "A prospect with the specified email address already exists"
+      'code' => '9',
+      '__content__' => 'A prospect with the specified email address already exists'
     }
   end
 
@@ -21,10 +21,10 @@ describe Pardot::ResponseError do
       described_class.new(@res)
     end
     specify do
-      subject.to_s.should == @res["__content__"]
+      subject.to_s.should == @res['__content__']
     end
     specify do
-      subject.message.should == @res["__content__"]
+      subject.message.should == @res['__content__']
     end
   end
 

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -18,8 +18,10 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=json&output=simple&user_key=bar",
+               { "err" => { "__content__" => "Login Failed", "code" => "15"},
+                 "stat" => "fail",
+                 "version"=>"1.0"}.to_json
       
       lambda { get }.should raise_error(Pardot::ResponseError)
     end
@@ -31,9 +33,11 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
-      
+      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=json&output=simple&user_key=bar",
+               { "err" => { "__content__" => "Invalid API key or user key", "code" => "15"},
+                 "stat" => "fail",
+                 "version"=>"1.0"}.to_json
+
       @client.should_receive(:handle_expired_api_key)
       get
     end
@@ -47,8 +51,10 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+      fake_post "/api/foo/version/3/bar",
+                { "err" => { "__content__" => "Login Failed", "code" => "15"},
+                  "stat" => "fail",
+                  "version"=>"1.0"}.to_json
       
       lambda { post }.should raise_error(Pardot::ResponseError)
     end
@@ -60,8 +66,10 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+      fake_post "/api/foo/version/3/bar",
+                { "err" => { "__content__" => "Invalid API key or user key", "code" => "15"},
+                  "stat" => "fail",
+                  "version"=>"1.0"}.to_json
       
       @client.should_receive(:handle_expired_api_key)
       post

--- a/spec/pardot/objects/emails_spec.rb
+++ b/spec/pardot/objects/emails_spec.rb
@@ -1,0 +1,44 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Pardot::Objects::Emails do
+
+  let!(:client) { create_client }
+
+  let(:response) do
+    { 'email' => {
+        'id' => 1,
+        'name' => 'Test',
+        'subject' => 'Testing',
+        'message' => { 'text' => 'Content!',
+                       'html' => '<html><body><p>Content!</p></body></html>' } } }
+  end
+
+  describe 'read' do
+    it 'find an email by id' do
+      fake_get '/api/email/version/3/do/read/id/1?user_key=bar&api_key=my_api_key&format=json&output=simple',
+               response.to_json
+
+      client.emails.read_by_id(1).should == response['email']
+    end
+  end
+  
+  describe 'send' do
+    it 'should send an email to a prospect by id' do
+      fake_post '/api/email/version/3/do/send/prospect_id/10', response.to_json
+      
+      client.emails.send_by_id(10).should == response['email']
+    end
+
+    it 'should send an email to a prospect by email' do
+      fake_post '/api/email/version/3/do/send/prospect_email/fake@email.com', response.to_json
+
+      client.emails.send_by_email('fake@email.com').should == response['email']
+    end
+
+    it 'should send an email to a list' do
+      fake_post '/api/email/version/3/do/send', response.to_json
+
+      client.emails.send_to_lists(10, [5, 6, 7], :email_template_id => 5).should == response['email']
+    end
+  end
+end

--- a/spec/pardot/objects/lists_spec.rb
+++ b/spec/pardot/objects/lists_spec.rb
@@ -1,41 +1,21 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Lists do
-  
-  before do
-    @client = create_client
+
+  let!(:client) { create_client }
+
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'list'          => [{ 'name' => 'Asdf List' }, { 'name' => 'Qwerty List' }] }
+    end
+
+    it 'should take in some arguments' do
+      fake_get '/api/list/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=json&output=simple&user_key=bar',
+               response.to_json
+
+      client.lists.query(:id_greater_than => 200).should == response
+    end
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <list>
-            <name>Asdf List</name>
-          </list>
-          <list>
-            <name>Qwerty List</name>
-          </list>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/list/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=simple&user_key=bar", sample_results
-      
-      @client.lists.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "list"=>[
-          {"name"=>"Asdf List"}, 
-          {"name"=>"Qwerty List"}
-        ]}
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/opportunities_spec.rb
+++ b/spec/pardot/objects/opportunities_spec.rb
@@ -1,64 +1,41 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Opportunities do
-  
-  before do
-    @client = create_client
+
+  let!(:client) { create_client }
+
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'opportunity'   =>
+            [{ 'name' => 'Jim',
+               'type' => 'Great' },
+             { 'name' => 'Sue',
+               'type' => 'Good' }] }
+    end
+
+    it 'should take in some arguments' do
+      fake_get '/api/opportunity/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=json&output=simple&user_key=bar',
+               response.to_json
+
+      client.opportunities.query(:id_greater_than => 200).should == response
+    end
+
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <opportunity>
-            <name>Jim</name>
-            <type>Great</type>
-          </opportunity>
-          <opportunity>
-            <name>Sue</name>
-            <type>Good</type>
-          </opportunity>
-        </result>
-      </rsp>)
+
+  describe 'create_by_email' do
+
+    let(:response) do
+      { 'opportunity' =>
+            { 'name' => 'Jim',
+              'type' => 'Good' } }
     end
-    
-    before do
-      @client = create_client
+
+    it 'should return the prospect' do
+      fake_post '/api/opportunity/version/3/do/create/prospect_email/user@test.com', response.to_json
+
+      client.opportunities.create_by_email('user@test.com', :name => 'Jim', :type => 'Good').should == response['opportunity']
     end
-    
-    it "should take in some arguments" do
-      fake_get "/api/opportunity/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=simple&user_key=bar", sample_results
-      
-      @client.opportunities.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "opportunity"=>[
-          {"type"=>"Great", "name"=>"Jim"}, 
-          {"type"=>"Good", "name"=>"Sue"}
-        ]}
-    end
-    
   end
-  
-  describe "create_by_email" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <opportunity>
-          <name>Jim</name>
-          <type>Good</type>
-        </opportunity>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/opportunity/version/3/do/create/prospect_email/user@test.com?type=Good&api_key=my_api_key&user_key=bar&format=simple&name=Jim", sample_results
-      
-      @client.opportunities.create_by_email("user@test.com", :name => "Jim", :type => "Good").should == {"name"=>"Jim", "type"=>"Good"}
-      
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/prospects_spec.rb
+++ b/spec/pardot/objects/prospects_spec.rb
@@ -1,61 +1,41 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Prospects do
-  
-  before do
-    @client = create_client
+
+  let!(:client) { create_client }
+
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'prospect'      =>
+            [{ 'first_name' => 'Jim',
+               'last_name'  => 'Smith' },
+             { 'first_name' => 'Sue',
+               'last_name'  => 'Green' }] }
+    end
+
+    it 'should take in some arguments' do
+      fake_get '/api/prospect/version/3/do/query?api_key=my_api_key&assigned=true&format=json&output=simple&user_key=bar',
+               response.to_json
+
+      client.prospects.query(:assigned => true).should == response
+    end
+
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <prospect>
-            <first_name>Jim</first_name>
-            <last_name>Smith</last_name>
-          </prospect>
-          <prospect>
-            <first_name>Sue</first_name>
-            <last_name>Green</last_name>
-          </prospect>
-        </result>
-      </rsp>)
+
+  describe 'create' do
+
+    let(:response) do
+      { 'prospect' => { 'first_name' => 'Jim', 'last_name' => 'Smith' } }
     end
-    
-    it "should take in some arguments" do
-      fake_get "/api/prospect/version/3/do/query?assigned=true&format=simple&user_key=bar&api_key=my_api_key", sample_results
-      
-      @client.prospects.query(:assigned => true).should == {"total_results" => 2, 
-        "prospect"=>[
-          {"last_name"=>"Smith", "first_name"=>"Jim"}, 
-          {"last_name"=>"Green", "first_name"=>"Sue"}
-        ]}
+
+    it 'should return the prospect' do
+      fake_post '/api/prospect/version/3/do/create/email/user@test.com', response.to_json
+
+      client.prospects.create('user@test.com', :first_name => 'Jim').should == response['prospect']
     end
-    
+
   end
-  
-  describe "create" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <prospect>
-          <first_name>Jim</first_name>
-          <last_name>Smith</last_name>
-        </prospect>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/prospect/version/3/do/create/email/user@test.com?api_key=my_api_key&user_key=bar&format=simple&first_name=Jim", sample_results
-      
-      @client.prospects.create("user@test.com", :first_name => "Jim").should == {"last_name"=>"Smith", "first_name"=>"Jim"}
-      
-    end
-    
-  end
-  
+
 end

--- a/spec/pardot/objects/users_spec.rb
+++ b/spec/pardot/objects/users_spec.rb
@@ -1,64 +1,37 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Users do
-  
-  before do
-    @client = create_client
+
+  let!(:client) { create_client }
+
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'user'          =>
+            [{ 'email' => 'user@test.com', 'first_name' => 'Jim' },
+             { 'email' => 'user@example.com', 'first_name' => 'Sue' }] }
+    end
+
+    it 'should take in some arguments' do
+      fake_get '/api/user/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=json&output=simple',
+               response.to_json
+
+      client.users.query(:id_greater_than => 200).should == response
+    end
+
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <user>
-            <email>user@test.com</email>
-            <first_name>Jim</first_name>
-          </user>
-          <user>
-            <email>user@example.com</email>
-            <first_name>Sue</first_name>
-          </user>
-        </result>
-      </rsp>)
+
+  describe 'read_by_email' do
+
+    let(:response) do
+      { 'user' => { 'email' => 'user@test.com', 'first_name' => 'Jim' } }
     end
-    
-    before do
-      @client = create_client
+
+    it 'should return the prospect' do
+      fake_post '/api/user/version/3/do/read/email/user@test.com', response.to_json
+
+      client.users.read_by_email('user@test.com').should == response['user']
     end
-    
-    it "should take in some arguments" do
-      fake_get "/api/user/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
-      
-      @client.users.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "user"=>[
-          {"email"=>"user@test.com", "first_name"=>"Jim"}, 
-          {"email"=>"user@example.com", "first_name"=>"Sue"}
-        ]}
-    end
-    
   end
-  
-  describe "read_by_email" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <user>
-          <email>user@example.com</email>
-          <first_name>Sue</first_name>
-        </user>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/user/version/3/do/read/email/user@test.com?api_key=my_api_key&user_key=bar&format=simple", sample_results
-      
-      @client.users.read_by_email("user@test.com").should == {"email"=>"user@example.com", "first_name"=>"Sue"}
-      
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/visitor_activities_spec.rb
+++ b/spec/pardot/objects/visitor_activities_spec.rb
@@ -1,64 +1,37 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::VisitorActivities do
-  
-  before do
-    @client = create_client
+
+  let!(:client) { create_client }
+
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'visitorActivity'          =>
+            [{ 'type_name' => 'Read', 'details' => 'Some details' },
+             { 'type_name' => 'Write', 'detail' => 'More details' }] }
+    end
+    
+    it 'should take in some arguments' do
+      fake_get '/api/visitorActivity/version/3/do/query?user_key=bar&api_key=my_api_key&id_greater_than=200&format=json&output=simple',
+               response.to_json
+      
+      client.visitor_activities.query(:id_greater_than => 200).should == response
+    end
   end
   
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visitorActivity>
-            <type_name>Read</type_name>
-            <details>Some details</details>
-          </visitorActivity>
-          <visitorActivity>
-            <type_name>Write</type_name>
-            <details>More details</details>
-          </visitorActivity>
-        </result>
-      </rsp>)
+  describe 'read' do
+
+    let(:response) do
+      {  'visitorActivity' => { 'type_name' => 'Write', 'details' => 'More details' } }
     end
     
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visitorActivity/version/3/do/query?user_key=bar&api_key=my_api_key&id_greater_than=200&format=simple", sample_results
+    it 'should return the prospect' do
+      fake_post '/api/visitorActivity/version/3/do/read/id/10',
+                response.to_json
       
-      @client.visitor_activities.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "visitorActivity"=>[
-          {"type_name"=>"Read", "details"=>"Some details"}, 
-          {"type_name"=>"Write", "details"=>"More details"}
-        ]}
+      client.visitor_activities.read(10).should == response['visitorActivity']
     end
-    
   end
-  
-  describe "read" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visitorActivity>
-          <type_name>Write</type_name>
-          <details>More details</details>
-        </visitorActivity>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/visitorActivity/version/3/do/read/id/10?user_key=bar&api_key=my_api_key&format=simple", sample_results
-      
-      @client.visitor_activities.read(10).should == {"details"=>"More details", "type_name"=>"Write"}
-      
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/visitors_spec.rb
+++ b/spec/pardot/objects/visitors_spec.rb
@@ -1,64 +1,36 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Visitors do
+
+  let!(:client) { create_client }
   
-  before do
-    @client = create_client
+  describe 'query' do
+
+    let(:response) do
+      { 'total_results' => 2,
+        'visitor'          =>
+            [{ 'browser' => 'Firefox', 'language' => 'en' },
+             { 'browser' => 'Chrome', 'language' => 'es' }] }
+    end
+    
+    it 'should take in some arguments' do
+      fake_get '/api/visitor/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=json&output=simple',
+               response.to_json
+
+      client.visitors.query(:id_greater_than => 200).should == response
+    end
   end
   
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visitor>
-            <browser>Firefox</browser>
-            <language>en</language>
-          </visitor>
-          <visitor>
-            <browser>Chrome</browser>
-            <language>es</language>
-          </visitor>
-        </result>
-      </rsp>)
+  describe 'assign' do
+
+    let(:response) do
+      { 'visitor' => { 'browser' => 'Chrome', 'language' => 'es' } }
     end
     
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visitor/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
+    it 'should return the prospect' do
+      fake_post '/api/visitor/version/3/do/assign/id/10', response.to_json
       
-      @client.visitors.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "visitor"=>[
-          {"browser"=>"Firefox", "language"=>"en"}, 
-          {"browser"=>"Chrome", "language"=>"es"}
-        ]}
+      client.visitors.assign(10, :name => 'Jim', :type => 'Good').should == response['visitor']
     end
-    
   end
-  
-  describe "assign" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visitor>
-          <browser>Chrome</browser>
-          <language>es</language>
-        </visitor>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/visitor/version/3/do/assign/id/10?type=Good&api_key=my_api_key&user_key=bar&format=simple&name=Jim", sample_results
-      
-      @client.visitors.assign(10, :name => "Jim", :type => "Good").should == {"browser"=>"Chrome", "language"=>"es"}
-      
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/visits_spec.rb
+++ b/spec/pardot/objects/visits_spec.rb
@@ -1,61 +1,36 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Visits do
+
+  let!(:client) { create_client }
   
-  before do
-    @client = create_client
-  end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visit>
-            <duration_in_seconds>50</duration_in_seconds>
-            <visitor_page_view_count>3</visitor_page_view_count>
-          </visit>
-          <visit>
-            <duration_in_seconds>10</duration_in_seconds>
-            <visitor_page_view_count>1</visitor_page_view_count>
-          </visit>
-        </result>
-      </rsp>)
+  describe 'query' do
+    let (:response) do
+      { 'total_results' => 2,
+        'visit'          =>
+            [{ 'duration_in_seconds' => '50', 'visitor_page_view_count' => '3' },
+             { 'duration_in_seconds' => '10', 'visitor_page_view_count' => '1' }] }
     end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visit/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
+
+    it 'should take in some arguments' do
+      fake_get '/api/visit/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=json&output=simple',
+               response.to_json
       
-      @client.visits.query(:id_greater_than => 200).should == {"total_results" => 2, 
-        "visit"=>[
-          {"duration_in_seconds"=>"50", "visitor_page_view_count"=>"3"}, 
-          {"duration_in_seconds"=>"10", "visitor_page_view_count"=>"1"}
-        ]}
+      client.visits.query(:id_greater_than => 200).should == response
     end
     
   end
   
-  describe "read" do
+  describe 'read' do
     
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visit>
-          <duration_in_seconds>10</duration_in_seconds>
-          <visitor_page_view_count>1</visitor_page_view_count>
-        </visit>
-      </rsp>)
+    let (:response) do
+      {'visit' => { 'duration_in_seconds' => '10', 'visitor_page_view_count' => '1' } }
     end
     
-    it "should return the prospect" do
-      fake_post "/api/visit/version/3/do/read/id/10?user_key=bar&api_key=my_api_key&format=simple", sample_results
+    it 'should return the prospect' do
+      fake_post '/api/visit/version/3/do/read/id/10', response.to_json
       
-      @client.visits.read(10).should == {"visitor_page_view_count"=>"1", "duration_in_seconds"=>"10"}
+      client.visits.read(10).should == response['visit']
       
     end
     

--- a/spec/support/client_support.rb
+++ b/spec/support/client_support.rb
@@ -1,6 +1,6 @@
 
 def create_client
-  @client = Pardot::Client.new "user@test.com", "foo", "bar"
-  @client.api_key = "my_api_key"
-  @client
+  client = Pardot::Client.new "user@test.com", "foo", "bar"
+  client.api_key = "my_api_key"
+  client
 end

--- a/spec/support/fakeweb.rb
+++ b/spec/support/fakeweb.rb
@@ -2,11 +2,12 @@ require 'fakeweb'
 FakeWeb.allow_net_connect = false
 
 def fake_post path, response
-  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response)
+  content_type = (/login/ === path) ? 'text/xml' : 'application/json'
+  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response, :content_type => content_type)
 end
 
 def fake_get path, response
-  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response)
+  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response, :content_type => 'application/json')
 end
 
 def fake_authenticate client, api_key


### PR DESCRIPTION
This builds on my previous pull request and adds in support for the new email API endpoints:

http://developer.pardot.com/kb/api-version-3/reading-emails
http://developer.pardot.com/kb/api-version-3/sending-one-to-one-emails
http://developer.pardot.com/kb/api-version-3/sending-list-emails
