### PR TITLE
Handle additional net-related errors

### DIFF
--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -9,7 +9,7 @@ module Pardot
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :get, object, path, params, num_retries, e
       
-    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error => e
+    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
       raise Pardot::NetError.new(e)
     end
     
@@ -21,7 +21,7 @@ module Pardot
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
       
-    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error => e
+    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
       raise Pardot::NetError.new(e)
     end
     


### PR DESCRIPTION
I've been running thousands of requests every day using this gem, and there's a handful of net-related exceptions that the gem should catch and wrap in Pardot::NetError so I don't need to catch additional exception types
