### PR TITLE
fix gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ruby-pardot.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       httparty
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     crack (0.4.2)
       safe_yaml (~> 1.0.0)


### PR DESCRIPTION
> The source :gemcutter is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
