### PR TITLE
Add `assign` to prospect accounts

### DIFF
--- a/lib/pardot/objects/prospect_accounts.rb
+++ b/lib/pardot/objects/prospect_accounts.rb
@@ -2,7 +2,8 @@ module Pardot
   module Objects
     module ProspectAccounts
       def prospect_accounts
-        @prospect_accounts ||= ProspectAccounts.new self
+        @prospect_accounts ||=
+          ::Pardot::Objects::ProspectAccounts::ProspectAccounts.new(self)
       end
 
       class ProspectAccounts
@@ -26,11 +27,18 @@ module Pardot
           post('/do/create', params)
         end
 
-        # read, update, assign (all are by id)
-        [:read, :update, :assign].each do |verb|
-          define_method(verb) do |id, params={}|
-            post(api_url(verb, 'id', id), params)
-          end
+        def read(id, params={})
+          post(api_url('read', 'id', id), params)
+        end
+
+        def update(id, params={})
+          post(api_url('update', 'id', id), params)
+        end
+
+        # params must include either `user_email`,
+        # `user_id`, or `group_id`
+        def assign(id, params={})
+          post(api_url('assign', 'id', id), params)
         end
 
         private

--- a/lib/pardot/objects/prospect_accounts.rb
+++ b/lib/pardot/objects/prospect_accounts.rb
@@ -26,9 +26,7 @@ module Pardot
           post('/do/create', params)
         end
 
-        # read_by_id
-        # update_by_id
-        # assign_by_id
+        # read, update, assign (all are by id)
         [:read, :update, :assign].each do |verb|
           define_method(verb) do |id, params={}|
             post(api_url(verb, 'id', id), params)

--- a/lib/pardot/objects/prospect_accounts.rb
+++ b/lib/pardot/objects/prospect_accounts.rb
@@ -28,7 +28,8 @@ module Pardot
 
         # read_by_id
         # update_by_id
-        [:read, :update].each do |verb|
+        # assign_by_id
+        [:read, :update, :assign].each do |verb|
           define_method(verb) do |id, params={}|
             post(api_url(verb, 'id', id), params)
           end

--- a/spec/pardot/objects/prospect_accounts_spec.rb
+++ b/spec/pardot/objects/prospect_accounts_spec.rb
@@ -54,7 +54,6 @@ describe Pardot::Objects::ProspectAccounts do
 
   end
 
-
   describe 'create' do
 
     def sample_results
@@ -73,6 +72,28 @@ describe Pardot::Objects::ProspectAccounts do
 
     end
 
+  end
+
+  describe 'assign' do
+    def sample_results
+      %(<?xml version="1.0" encoding="UTF-8"?>
+      <rsp stat="ok" version="1.0">
+        <prospectAccount>
+          <id>1234</id>
+          <name>SuperPanda</name>
+          <assigned_to>
+            <user_id>4321</user_id>
+            <user_email>pandaklaus@northpole.np</user_email>
+          </assigned_to>
+        </prospectAccount>
+      </rsp>)
+    end
+
+    it 'should return the prospect account with the assigned_to tag' do
+      fake_post '/api/prospectAccount/version/3/do/assign/id/1234?api_key=my_api_key&user_key=bar&format=simple&user_id=4321', sample_results
+
+      @client.prospect_accounts.assign('1234', {:user_id => '4321'}).should == {'id' => '1234', 'name' => 'SuperPanda', 'assigned_to' => { 'user_id' => '4321', 'user_email' => 'pandaklaus@northpole.np' }}
+    end
   end
 
 end


### PR DESCRIPTION
'assign' is actually not included in the documentation, but I found that it works for not only Prospects but Prospect Accounts as well.
- Added spec for 'assign'
- Added code for 'assign' in ProspectAccounts object.

Additionally:
- Modified meta-programming approach for #read and #update so that the code is more self-documenting and IDEs include the methods in auto-complete.
- Modified the object instantiation on line 5 to include parent modules too for clarity.
