### PR TITLE
Handle nil response when authenticating.

### DIFF
--- a/lib/pardot/authentication.rb
+++ b/lib/pardot/authentication.rb
@@ -3,7 +3,7 @@ module Pardot
     
     def authenticate
       resp = post "login", nil, :email => @email, :password => @password, :user_key => @user_key
-      @api_key = resp["api_key"]
+      @api_key = resp && resp["api_key"]
     end
     
     def authenticated?


### PR DESCRIPTION
re:
https://github.com/Pardot/ruby-pardot/issues/17

This should solve that issue. Returning nil from `authenticate` causes the client to attempt a request with a nil api key, which results in `Pardot::ResponseError: Invalid API key or user key` which is reasonable behavior.