### PR TITLE
Fix RDoc formating and update broken API v3 links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -57,7 +57,7 @@ http://developer.pardot.com/kb/api-version-3/using-prospects
   
 === Emails
 
-See each individual call's [API reference page](http://developer.pardot.com/kb/api-version-3/introduction-table-of-contents).
+See each individual call's {API reference page}[http://developer.pardot.com/kb/api-version-3/introduction-table-of-contents].
 
   # Sample usage
   @pardot.emails.read_by_id(email_id)

--- a/README.rdoc
+++ b/README.rdoc
@@ -31,7 +31,7 @@ The available objects are:
 
 === Querying Objects
   
-http://developer.pardot.com/kb/api-version-3/querying-prospects
+http://developer.pardot.com/kb/api-version-3/prospects/#querying-prospects
   
 Most objects accept limit, offset, sort_by, and sord_order parameters
 
@@ -47,7 +47,7 @@ Most objects accept limit, offset, sort_by, and sord_order parameters
 
 See each individual object's API reference page for available methods
 
-http://developer.pardot.com/kb/api-version-3/using-prospects
+http://developer.pardot.com/kb/api-version-3/prospects/#using-prospects
 
   prospect = client.prospects.create("user@test.com", :first_name => "John", :last_name => "Doe")
   
@@ -57,7 +57,7 @@ http://developer.pardot.com/kb/api-version-3/using-prospects
   
 === Emails
 
-See each individual call's {API reference page}[http://developer.pardot.com/kb/api-version-3/introduction-table-of-contents].
+See each individual call's {API reference page}[http://developer.pardot.com/kb/api-version-3/emails/].
 
   # Sample usage
   @pardot.emails.read_by_id(email_id)


### PR DESCRIPTION
Hi 👋 

I noticed that API documentation links were broken, and that Markdown formatting was used for links instead of RDoc formatting i.e. `[link](example.org)` instead of `{link}[example.org]`. Fix attached :metal: 