### PR TITLE
W-6115601 Update all functions to use Authorization header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.2.0)
+    ruby-pardot (1.3.0)
       crack (= 0.4.3)
       httparty (= 0.13.1)
 
@@ -25,7 +25,7 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
 
 PLATFORMS
   ruby

--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -4,7 +4,8 @@ module Pardot
     def get object, path, params = {}, num_retries = 0
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.get(full_path, :query => params)
+      headers = create_auth_header object
+      check_response self.class.get(full_path, :query => params, :headers => headers)
       
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :get, object, path, params, num_retries, e
@@ -16,7 +17,8 @@ module Pardot
     def post object, path, params = {}, num_retries = 0, bodyParams = {}
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params, :body => bodyParams)
+      headers = create_auth_header object
+      check_response self.class.post(full_path, :query => params, :body => bodyParams, :headers => headers)
       
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
@@ -39,7 +41,12 @@ module Pardot
       return if object == "login"
       
       authenticate unless authenticated?
-      params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
+      params.merge! :format => @format
+    end
+
+    def create_auth_header object
+      return if object == "login"
+      { :Authorization => "Pardot api_key=#{@api_key}, user_key=#{@user_key}" }
     end
     
     def check_response http_response

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -18,7 +18,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
@@ -31,7 +31,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_get "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -47,7 +47,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
@@ -60,7 +60,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_post "/api/foo/version/3/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -77,7 +77,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_get "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
@@ -90,7 +90,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_get "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
@@ -107,7 +107,7 @@ describe Pardot::Http do
     end
     
     it "should notice errors and raise them as Pardot::ResponseError" do
-      fake_post "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
@@ -120,7 +120,7 @@ describe Pardot::Http do
     end
     
     it "should call handle_expired_api_key when the api key expires" do
-      fake_post "/api/foo/version/4/bar?api_key=my_api_key&format=simple&user_key=bar",
+      fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)

--- a/spec/pardot/objects/emails_spec.rb
+++ b/spec/pardot/objects/emails_spec.rb
@@ -19,18 +19,21 @@ describe Pardot::Objects::Emails do
   end
 
   it "should take in the email ID" do
-    fake_get "/api/email/version/3/do/read/id/12?user_key=bar&api_key=my_api_key&format=simple", sample_response
+    fake_get "/api/email/version/3/do/read/id/12?format=simple", sample_response
     @client.emails.read_by_id(12).should == {"name" => "My Email"}
+    assert_authorization_header
   end
 
   it 'should send to a prospect' do
-    fake_post '/api/email/version/3/do/send/prospect_id/42?campaign_id=765&email_template_id=86&user_key=bar&api_key=my_api_key&format=simple', sample_response
+    fake_post '/api/email/version/3/do/send/prospect_id/42?campaign_id=765&email_template_id=86&format=simple', sample_response
     @client.emails.send_to_prospect(42, :campaign_id => 765, :email_template_id => 86).should == {"name" => "My Email"}
+    assert_authorization_header
   end
 
   it 'should send to a list' do
-    fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids[]=235&campaign_id=654&user_key=bar&api_key=my_api_key&format=simple', sample_response
+    fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids[]=235&campaign_id=654&format=simple', sample_response
     @client.emails.send_to_list(:email_template_id => 200, 'list_ids[]' => 235, :campaign_id => 654).should == {"name" => "My Email"}
+    assert_authorization_header
   end
 
 end

--- a/spec/pardot/objects/lists_spec.rb
+++ b/spec/pardot/objects/lists_spec.rb
@@ -27,13 +27,14 @@ describe Pardot::Objects::Lists do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/list/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=simple&user_key=bar", sample_results
+      fake_get "/api/list/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.lists.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "list"=>[
           {"name"=>"Asdf List"}, 
           {"name"=>"Qwerty List"}
         ]}
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/opportunities_spec.rb
+++ b/spec/pardot/objects/opportunities_spec.rb
@@ -29,13 +29,14 @@ describe Pardot::Objects::Opportunities do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/opportunity/version/3/do/query?api_key=my_api_key&id_greater_than=200&format=simple&user_key=bar", sample_results
+      fake_get "/api/opportunity/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.opportunities.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "opportunity"=>[
           {"type"=>"Great", "name"=>"Jim"}, 
           {"type"=>"Good", "name"=>"Sue"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -53,10 +54,11 @@ describe Pardot::Objects::Opportunities do
     end
     
     it "should return the prospect" do
-      fake_post "/api/opportunity/version/3/do/create/prospect_email/user@test.com?type=Good&api_key=my_api_key&user_key=bar&format=simple&name=Jim", sample_results
+      fake_post "/api/opportunity/version/3/do/create/prospect_email/user@test.com?type=Good&format=simple&name=Jim", sample_results
       
       @client.opportunities.create_by_email("user@test.com", :name => "Jim", :type => "Good").should == {"name"=>"Jim", "type"=>"Good"}
-      
+
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/prospect_accounts_spec.rb
+++ b/spec/pardot/objects/prospect_accounts_spec.rb
@@ -24,13 +24,14 @@ describe Pardot::Objects::ProspectAccounts do
     end
 
     it "should take in some arguments and respond with valid items" do
-      fake_get "/api/prospectAccount/version/3/do/query?assigned=true&format=simple&user_key=bar&api_key=my_api_key", sample_results
+      fake_get "/api/prospectAccount/version/3/do/query?assigned=true&format=simple", sample_results
 
       @client.prospect_accounts.query(:assigned => true).should == {'total_results' => 2,
         'prospectAccount'=>[
           {'name'=>'Spaceships R Us'},
           {'name'=>'Monsters Inc'}
         ]}
+      assert_authorization_header
     end
 
   end
@@ -47,9 +48,10 @@ describe Pardot::Objects::ProspectAccounts do
     end
 
     it 'should return a valid account' do
-      fake_post '/api/prospectAccount/version/3/do/read/id/1234?assigned=true&format=simple&user_key=bar&api_key=my_api_key', sample_results
+      fake_post '/api/prospectAccount/version/3/do/read/id/1234?assigned=true&format=simple', sample_results
 
       @client.prospect_accounts.read('1234', :assigned => true).should == {'id' => '1234', 'name' => 'SupaDupaPanda' }
+      assert_authorization_header
     end
 
   end
@@ -67,10 +69,10 @@ describe Pardot::Objects::ProspectAccounts do
     end
 
     it 'should return the prospect account' do
-      fake_post '/api/prospectAccount/version/3/do/create?api_key=my_api_key&user_key=bar&format=simple&name=SuperPanda', sample_results
+      fake_post '/api/prospectAccount/version/3/do/create?format=simple&name=SuperPanda', sample_results
 
       @client.prospect_accounts.create(:name => 'SuperPanda').should == {"name"=>"SuperPanda"}
-
+      assert_authorization_header
     end
 
   end

--- a/spec/pardot/objects/prospects_spec.rb
+++ b/spec/pardot/objects/prospects_spec.rb
@@ -26,13 +26,14 @@ describe Pardot::Objects::Prospects do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/prospect/version/3/do/query?assigned=true&format=simple&user_key=bar&api_key=my_api_key", sample_results
+      fake_get "/api/prospect/version/3/do/query?assigned=true&format=simple", sample_results
       
       @client.prospects.query(:assigned => true).should == {"total_results" => 2, 
         "prospect"=>[
           {"last_name"=>"Smith", "first_name"=>"Jim"}, 
           {"last_name"=>"Green", "first_name"=>"Sue"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -50,10 +51,10 @@ describe Pardot::Objects::Prospects do
     end
     
     it "should return the prospect" do
-      fake_post "/api/prospect/version/3/do/create/email/user@test.com?api_key=my_api_key&user_key=bar&format=simple&first_name=Jim", sample_results
+      fake_post "/api/prospect/version/3/do/create/email/user@test.com?format=simple&first_name=Jim", sample_results
       
       @client.prospects.create("user@test.com", :first_name => "Jim").should == {"last_name"=>"Smith", "first_name"=>"Jim"}
-      
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/users_spec.rb
+++ b/spec/pardot/objects/users_spec.rb
@@ -29,13 +29,14 @@ describe Pardot::Objects::Users do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/user/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
+      fake_get "/api/user/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.users.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "user"=>[
           {"email"=>"user@test.com", "first_name"=>"Jim"}, 
           {"email"=>"user@example.com", "first_name"=>"Sue"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -53,10 +54,10 @@ describe Pardot::Objects::Users do
     end
     
     it "should return the prospect" do
-      fake_post "/api/user/version/3/do/read/email/user@test.com?api_key=my_api_key&user_key=bar&format=simple", sample_results
+      fake_post "/api/user/version/3/do/read/email/user@test.com?format=simple", sample_results
       
       @client.users.read_by_email("user@test.com").should == {"email"=>"user@example.com", "first_name"=>"Sue"}
-      
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/visitor_activities_spec.rb
+++ b/spec/pardot/objects/visitor_activities_spec.rb
@@ -29,13 +29,14 @@ describe Pardot::Objects::VisitorActivities do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/visitorActivity/version/3/do/query?user_key=bar&api_key=my_api_key&id_greater_than=200&format=simple", sample_results
+      fake_get "/api/visitorActivity/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.visitor_activities.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "visitorActivity"=>[
           {"type_name"=>"Read", "details"=>"Some details"}, 
           {"type_name"=>"Write", "details"=>"More details"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -53,10 +54,10 @@ describe Pardot::Objects::VisitorActivities do
     end
     
     it "should return the prospect" do
-      fake_post "/api/visitorActivity/version/3/do/read/id/10?user_key=bar&api_key=my_api_key&format=simple", sample_results
+      fake_post "/api/visitorActivity/version/3/do/read/id/10?format=simple", sample_results
       
       @client.visitor_activities.read(10).should == {"details"=>"More details", "type_name"=>"Write"}
-      
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/visitors_spec.rb
+++ b/spec/pardot/objects/visitors_spec.rb
@@ -29,13 +29,14 @@ describe Pardot::Objects::Visitors do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/visitor/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
+      fake_get "/api/visitor/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.visitors.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "visitor"=>[
           {"browser"=>"Firefox", "language"=>"en"}, 
           {"browser"=>"Chrome", "language"=>"es"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -53,10 +54,10 @@ describe Pardot::Objects::Visitors do
     end
     
     it "should return the prospect" do
-      fake_post "/api/visitor/version/3/do/assign/id/10?type=Good&api_key=my_api_key&user_key=bar&format=simple&name=Jim", sample_results
+      fake_post "/api/visitor/version/3/do/assign/id/10?type=Good&format=simple&name=Jim", sample_results
       
       @client.visitors.assign(10, :name => "Jim", :type => "Good").should == {"browser"=>"Chrome", "language"=>"es"}
-      
+      assert_authorization_header
     end
     
   end

--- a/spec/pardot/objects/visits_spec.rb
+++ b/spec/pardot/objects/visits_spec.rb
@@ -29,13 +29,14 @@ describe Pardot::Objects::Visits do
     end
     
     it "should take in some arguments" do
-      fake_get "/api/visit/version/3/do/query?api_key=my_api_key&user_key=bar&id_greater_than=200&format=simple", sample_results
+      fake_get "/api/visit/version/3/do/query?id_greater_than=200&format=simple", sample_results
       
       @client.visits.query(:id_greater_than => 200).should == {"total_results" => 2, 
         "visit"=>[
           {"duration_in_seconds"=>"50", "visitor_page_view_count"=>"3"}, 
           {"duration_in_seconds"=>"10", "visitor_page_view_count"=>"1"}
         ]}
+      assert_authorization_header
     end
     
   end
@@ -53,10 +54,10 @@ describe Pardot::Objects::Visits do
     end
     
     it "should return the prospect" do
-      fake_post "/api/visit/version/3/do/read/id/10?user_key=bar&api_key=my_api_key&format=simple", sample_results
+      fake_post "/api/visit/version/3/do/read/id/10?format=simple", sample_results
       
       @client.visits.read(10).should == {"visitor_page_view_count"=>"1", "duration_in_seconds"=>"10"}
-      
+      assert_authorization_header
     end
     
   end

--- a/spec/support/fakeweb.rb
+++ b/spec/support/fakeweb.rb
@@ -2,11 +2,11 @@ require 'fakeweb'
 FakeWeb.allow_net_connect = false
 
 def fake_post path, response
-  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response, :Authorization => 'user_key=bar&api_key=my_api_key')
+  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response)
 end
 
 def fake_get path, response
-  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response, :Authorization => 'user_key=bar&api_key=my_api_key')
+  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response)
 end
 
 def fake_authenticate client, api_key

--- a/spec/support/fakeweb.rb
+++ b/spec/support/fakeweb.rb
@@ -2,13 +2,17 @@ require 'fakeweb'
 FakeWeb.allow_net_connect = false
 
 def fake_post path, response
-  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response)
+  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response, :Authorization => 'user_key=bar&api_key=my_api_key')
 end
 
 def fake_get path, response
-  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response)
+  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response, :Authorization => 'user_key=bar&api_key=my_api_key')
 end
 
 def fake_authenticate client, api_key
   client.api_key = api_key
+end
+
+def assert_authorization_header
+  expect(FakeWeb.last_request[:authorization]).to eq('Pardot api_key=my_api_key, user_key=bar')
 end


### PR DESCRIPTION
This pull request changes the Pardot Ruby Client to use Authorization to authenticate with the Pardot API instead of passing the `user_key` and `api_key` as query string parameters.