### PR TITLE
Add support for querying `customField` objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.3.0)
+    ruby-pardot (1.3.2)
       crack (= 0.4.3)
       httparty (= 0.13.1)
 
@@ -37,4 +37,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,6 +20,7 @@ The client will authenticate before performing other API calls, but you can manu
 
 The available objects are:
 
+* custom_fields 
 * emails
 * lists
 * opportunities

--- a/lib/pardot/client.rb
+++ b/lib/pardot/client.rb
@@ -9,6 +9,7 @@ module Pardot
     include Authentication
     include Http
 
+    include Objects::CustomFields
     include Objects::Emails
     include Objects::Lists
     include Objects::ListMemberships

--- a/lib/pardot/objects/custom_fields.rb
+++ b/lib/pardot/objects/custom_fields.rb
@@ -1,0 +1,37 @@
+module Pardot
+  module Objects
+    module CustomFields
+      
+      def custom_fields
+        @custom_fields ||= CustomFields.new self
+      end
+      
+      class CustomFields
+        
+        def initialize client
+          @client = client
+        end
+        
+        def query params
+          result = get "/do/query", params, "result"
+          result["total_results"] = result["total_results"].to_i if result["total_results"]
+          result
+        end
+        
+        protected
+        
+        def get path, params = {}, result = "customField"
+          response = @client.get "customField", path, params
+          result ? response[result] : response
+        end
+        
+        def post path, params = {}, result = "user"
+          response = @client.post "customField", path, params
+          result ? response[result] : response
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/lib/ruby-pardot.rb
+++ b/lib/ruby-pardot.rb
@@ -6,6 +6,7 @@ require 'pardot/http'
 require 'pardot/error'
 require 'pardot/authentication'
 
+require 'pardot/objects/custom_fields'
 require 'pardot/objects/emails'
 require 'pardot/objects/lists'
 require 'pardot/objects/list_memberships'

--- a/spec/pardot/objects/custom_fields_spec.rb
+++ b/spec/pardot/objects/custom_fields_spec.rb
@@ -1,0 +1,58 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Pardot::Objects::CustomFields do
+  
+  before do
+    @client = create_client
+  end
+  
+  describe "query" do
+    
+    def sample_results
+      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+        <result>
+          <total_results>1</total_results>
+            <customField>
+              <created_at>2019-11-26 13:40:37</created_at>
+              <crm_id null="true" />
+              <field_id>CustomObject1574793618883</field_id>
+              <id>8932</id>
+              <is_record_multiple_responses>false</is_record_multiple_responses>
+              <is_use_values>false</is_use_values>
+              <name>Ω≈ç√∫˜µ≤≥÷</name>
+              <type>Text</type>
+              <type_id>1</type_id>
+              <updated_at>2019-11-26 13:40:37</updated_at>
+          </customField>
+        </result>
+      </rsp>)
+    end
+    
+    before do
+      @client = create_client
+    end
+    
+    it "should take in some arguments" do
+      fake_get "/api/customField/version/3/do/query?id_greater_than=200&format=simple", sample_results
+      
+      @client.custom_fields.query(:id_greater_than => 200).should == {"total_results" => 1, 
+        "customField"=>
+          {
+            "id"=>"8932",
+            "name"=>"Ω≈ç√∫˜µ≤≥÷",
+            "field_id"=>"CustomObject1574793618883",
+            "type"=>"Text",
+            "type_id"=>"1",
+            "crm_id"=>{"null"=>"true"},
+            "is_record_multiple_responses"=>"false",
+            "is_use_values"=>"false",
+            "created_at"=>"2019-11-26 13:40:37",
+            "updated_at"=>"2019-11-26 13:40:37"
+          }
+        }
+      assert_authorization_header
+    end
+    
+  end
+  
+end

--- a/spec/pardot/objects/prospects_spec.rb
+++ b/spec/pardot/objects/prospects_spec.rb
@@ -51,8 +51,8 @@ describe Pardot::Objects::Prospects do
     end
     
     it "should return the prospect" do
-      fake_post "/api/prospect/version/3/do/create/email/user@test.com?format=simple&first_name=Jim", sample_results
-      
+      fake_post "/api/prospect/version/3/do/create/email/user%40test.com?first_name=Jim&format=simple", sample_results
+
       @client.prospects.create("user@test.com", :first_name => "Jim").should == {"last_name"=>"Smith", "first_name"=>"Jim"}
       assert_authorization_header
     end


### PR DESCRIPTION
http://developer.pardot.com/kb/api-version-4/custom-fields/

Side note: It looks like master is currently broken, as the Gemfile references a previous version of the gem (1.3.0), and upon updating to 1.3.1, an unrelated spec fails, hence the additional change to `prospects_spec.rb`