### PR TITLE
Update httpparty dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-pardot (1.3.2)
       crack (= 0.4.3)
-      httparty (= 0.13.1)
+      httparty (= 0.17.3)
 
 GEM
   remote: http://rubygems.org/
@@ -12,10 +12,12 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.1.2)
     fakeweb (1.3.0)
-    httparty (0.13.1)
-      json (~> 1.8)
+    httparty (0.17.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (1.8.6)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     multi_xml (0.6.0)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
@@ -37,4 +39,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "ruby-pardot"
 
   s.add_dependency "crack", "0.4.3"
-  s.add_dependency "httparty", "0.13.1"
+  s.add_dependency "httparty", "0.17.3"
 
   s.add_development_dependency "bundler", ">= 1.10"
   s.add_development_dependency "rspec"

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -19,7 +19,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/3/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
     end
@@ -32,7 +32,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/3/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
       get
@@ -48,7 +48,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/3/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
     end
@@ -61,7 +61,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/3/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
       post
@@ -78,7 +78,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/4/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { get }.should raise_error(Pardot::ResponseError)
     end
@@ -91,7 +91,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/4/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
       get
@@ -108,7 +108,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/4/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       lambda { post }.should raise_error(Pardot::ResponseError)
     end
@@ -121,7 +121,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/4/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       @client.should_receive(:handle_expired_api_key)
       post


### PR DESCRIPTION
## Background
The current version of `ruby-pardot` has a dependency on the `0.13.0` version of `httpparty` which requires an older version of the `json` gem.  This can cause dependency incompatibilities when attempting to include the gem on projects that have a requirement of a newer version of the `json` gem.

Starting with version 0.14.0 of `httpparty`, the `json` dependency was removed completely.  This PR updates `httpparty` to the latest version.

## Detail
This PR does two things:
1.  Fix broken specs on `master` due to missing characters in the XML stubs in the `http-spec`
2.  Updates the `httpparty` gem dependency to the latest version

## References
* `httpparty` was pinned to `0.13.0` in [this commit](https://github.com/pardot/ruby-pardot/pull/37/files#r252454982)
* Issue https://github.com/pardot/ruby-pardot/issues/38 asks about why `httpparty` was pinned