### PR TITLE
Update httpparty & rspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,46 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.3.2)
+    ruby-pardot (1.4.0)
       crack (= 0.4.3)
-      httparty (= 0.13.1)
+      httparty (>= 0.13)
 
 GEM
   remote: http://rubygems.org/
   specs:
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.1.2)
+    diff-lcs (1.3)
     fakeweb (1.3.0)
-    httparty (0.13.1)
-      json (~> 1.8)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (1.8.6)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     multi_xml (0.6.0)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     safe_yaml (1.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.10)
-  fakeweb
-  rspec
+  bundler (~> 2)
+  fakeweb (~> 1.3)
+  rspec (~> 3.9)
   ruby-pardot!
 
 BUNDLED WITH

--- a/README.rdoc
+++ b/README.rdoc
@@ -58,13 +58,15 @@ http://developer.pardot.com/kb/api-version-3/using-prospects
 
 === Subscribing email addresses to lists
 
-Subscriptions to lists are managed through the Prospect object. [To add an email to a list, you can do it in an update on the Prospect object by passing the list_id as a query param](http://developer.pardot.com/kb/api-version-4/prospects/#updating-email-list-subscriptions) as follows:
+Subscriptions to lists are managed through the Prospect object. To add an email to a list, you can do it in an update on the Prospect object by passing the list_id as a query param as follows:
 
   #Sample usage
   email = 'your@email.address'
   list_id = '20303'
   params = { "list_#{list_id}": 1 }
   client.prospects.upsert_by_email(email, params)
+
+See http://developer.pardot.com/kb/api-version-4/prospects/#updating-email-list-subscriptions
 
 === Emails
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,16 +11,16 @@ Add the following to your Gemfile
 The client will authenticate before performing other API calls, but you can manually authenticate as well
 
   client = Pardot::Client.new email, password, user_key
-  
+
   # will raise a Pardot::ResponseError if login fails
   # will raise a Pardot::NetError if the http call fails
   client.authenticate
-  
+
 === Object Types
 
 The available objects are:
 
-* custom_fields 
+* custom_fields
 * emails
 * lists
 * opportunities
@@ -31,15 +31,15 @@ The available objects are:
 * visits
 
 === Querying Objects
-  
+
 http://developer.pardot.com/kb/api-version-3/querying-prospects
-  
+
 Most objects accept limit, offset, sort_by, and sord_order parameters
 
   prospects = client.prospects.query(:assigned => false, :sort_by => "last_activity_at", :limit => 20)
-  
+
   prospects["total_results"] # number of prospects found
-  
+
   prospects["prospect"].each do |prospect|
     puts prospect["first_name"]
   end
@@ -51,11 +51,21 @@ See each individual object's API reference page for available methods
 http://developer.pardot.com/kb/api-version-3/using-prospects
 
   prospect = client.prospects.create("user@test.com", :first_name => "John", :last_name => "Doe")
-  
+
   prospect.each do |key, value|
     puts "#{key} is #{value}"
   end
-  
+
+=== Subscribing email addresses to lists
+
+Subscriptions to lists are managed through the Prospect object. [To add an email to a list, you can do it in an update on the Prospect object by passing the list_id as a query param](http://developer.pardot.com/kb/api-version-4/prospects/#updating-email-list-subscriptions) as follows:
+
+  #Sample usage
+  email = 'your@email.address'
+  list_id = '20303'
+  params = { "list_#{list_id}": 1 }
+  client.prospects.upsert_by_email(email, params)
+
 === Emails
 
 See each individual call's [API reference page](http://developer.pardot.com/kb/api-version-3/introduction-table-of-contents).
@@ -64,15 +74,15 @@ See each individual call's [API reference page](http://developer.pardot.com/kb/a
   @pardot.emails.read_by_id(email_id)
   @pardot.emails.send_to_list(:email_template_id => template_id, 'list_ids[]' => list_id, :campaign_id => campaign_id)
   @pardot.emails.send_to_prospect(prospect_id, :campaign_id => campaign_id, :email_template_id => template_id)
-  
+
 === Output formats
-  
+
   client.format = "simple" # default
   client.format = "mobile"
   client.format = "full"
 
 === Error handling
-  
+
 Pardot will respond with an error message when you provide invalid parameters
 
   begin
@@ -82,7 +92,7 @@ Pardot will respond with an error message when you provide invalid parameters
   end
 
 Performing API calls across the internet is inherently unsafe, so be sure to catch the exceptions
-  
+
   begin
     visitor = client.visitors.query(:id_greater_than => 200)
   rescue Pardot::NetError => e
@@ -101,10 +111,10 @@ files (the "Software"), to deal in the Software without restriction, including w
 modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
 Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.3.2"
+  VERSION = "1.4.0"
 end

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -1,27 +1,28 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path("../lib/pardot/version", __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('../lib/pardot/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "ruby-pardot"
+  s.name        = 'ruby-pardot'
   s.version     = Pardot::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Dan Cunning"]
-  s.email       = ["support@pardot.com"]
-  s.homepage    = "http://github.com/pardot/ruby-pardot"
-  s.summary     = "Library for interacting with the Pardot API"
-  s.description = "Library for interacting with the Pardot API"
+  s.authors     = ['Dan Cunning']
+  s.email       = ['support@pardot.com']
+  s.homepage    = 'http://github.com/pardot/ruby-pardot'
+  s.summary     = 'Library for interacting with the Pardot API'
+  s.description = 'Library for interacting with the Pardot API'
 
-  s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "ruby-pardot"
+  s.required_rubygems_version = '>= 1.3.6'
+  s.rubyforge_project         = 'ruby-pardot'
 
-  s.add_dependency "crack", "0.4.3"
-  s.add_dependency "httparty", "0.13.1"
+  s.add_dependency 'crack', '0.4.3'
+  s.add_dependency 'httparty', '>= 0.13'
 
-  s.add_development_dependency "bundler", ">= 1.10"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "fakeweb"
+  s.add_development_dependency 'bundler', '~> 2'
+  s.add_development_dependency 'fakeweb', '~> 1.3'
+  s.add_development_dependency 'rspec', '~> 3.9'
 
   s.files        = `git ls-files`.split("\n")
-  s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
+  s.executables  = `git ls-files`.split("\n").map { |f| f =~ %r{^bin\/(.*)} ? $1 : nil }.compact
   s.require_path = 'lib'
 end

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -1,132 +1,132 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Pardot::Http do
-  
+
   before do
     @client = create_client
     fake_authenticate @client, "my_api_key"
   end
-  
+
   def create_client
     @client = Pardot::Client.new "user@test.com", "foo", "bar"
   end
-  
+
   describe "get" do
-    
+
     def get object = "foo", path = "/bar", params = {}
       @client.get object, path, params
     end
-    
+
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
-      
+
       lambda { get }.should raise_error(Pardot::ResponseError)
     end
-    
+
     it "should catch and reraise SocketErrors as Pardot::NetError" do
-      Pardot::Client.should_receive(:get).and_raise(SocketError)
-      
+      Pardot::Client.expect(:get).and_raise(SocketError)
+
       lambda { get }.should raise_error(Pardot::NetError)
     end
-    
+
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/3/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
-      
-      @client.should_receive(:handle_expired_api_key)
+
+      @client.expect(:handle_expired_api_key)
       get
     end
-    
+
   end
-  
+
   describe "post" do
-    
+
     def post object = "foo", path = "/bar", params = {}
       @client.post object, path, params
     end
-    
+
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
-      
+
       lambda { post }.should raise_error(Pardot::ResponseError)
     end
-    
+
     it "should catch and reraise SocketErrors as Pardot::NetError" do
-      Pardot::Client.should_receive(:post).and_raise(SocketError)
-      
+      Pardot::Client.expect(:post).and_raise(SocketError)
+
       lambda { post }.should raise_error(Pardot::NetError)
     end
-    
+
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/3/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
-      
-      @client.should_receive(:handle_expired_api_key)
+
+      @client.expect(:handle_expired_api_key)
       post
     end
-    
+
   end
 
   describe "getV4" do
-    
+
     def get object = "foo", path = "/bar", params = {}
       @client.version = "4"
       @client.get object, path, params
     end
-    
+
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
-      
+
       lambda { get }.should raise_error(Pardot::ResponseError)
     end
-    
+
     it "should catch and reraise SocketErrors as Pardot::NetError" do
-      Pardot::Client.should_receive(:get).and_raise(SocketError)
-      
+      Pardot::Client.expect(:get).and_raise(SocketError)
+
       lambda { get }.should raise_error(Pardot::NetError)
     end
-    
+
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/4/bar?format=simple",
                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
-      
-      @client.should_receive(:handle_expired_api_key)
+
+      @client.expect(:handle_expired_api_key)
       get
     end
-    
+
   end
-  
+
   describe "postV4" do
-    
+
     def post object = "foo", path = "/bar", params = {}
       @client.version = "4"
       @client.post object, path, params
     end
-    
+
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
-      
+
       lambda { post }.should raise_error(Pardot::ResponseError)
     end
-    
+
     it "should catch and reraise SocketErrors as Pardot::NetError" do
-      Pardot::Client.should_receive(:post).and_raise(SocketError)
-      
+      Pardot::Client.expect(:post).and_raise(SocketError)
+
       lambda { post }.should raise_error(Pardot::NetError)
     end
-    
+
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/4/bar?format=simple",
                 %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
-      
-      @client.should_receive(:handle_expired_api_key)
+
+      @client.expect(:handle_expired_api_key)
       post
     end
-    
+
   end
-  
+
 end

--- a/spec/support/fakeweb.rb
+++ b/spec/support/fakeweb.rb
@@ -1,18 +1,18 @@
 require 'fakeweb'
 FakeWeb.allow_net_connect = false
 
-def fake_post path, response
-  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", :body => response)
+def fake_post(path, response)
+  FakeWeb.register_uri(:post, "https://pi.pardot.com#{path}", body: response)
 end
 
-def fake_get path, response
-  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", :body => response)
+def fake_get(path, response)
+  FakeWeb.register_uri(:get, "https://pi.pardot.com#{path}", body: response)
 end
 
-def fake_authenticate client, api_key
+def fake_authenticate(client, api_key)
   client.api_key = api_key
 end
 
 def assert_authorization_header
-  expect(FakeWeb.last_request[:authorization]).to eq('Pardot api_key=my_api_key, user_key=bar')
+  expect(FakeWeb.last_request['authorization']).to eq('Pardot api_key=my_api_key, user_key=bar')
 end


### PR DESCRIPTION
## Purpose

I needed to be able to use this gem with a more modern version of `httpparty` similar to what was done in #47. 

After updating, the test suite failed, so I updated `rspec` as part of the process of resolving the error and handling a deprecation warning.

There are some slight styling changes -- preferring `:` over `=>` in hashes and some rubocop complaints -- and the diffs a little noisy because my editor removed whitespace padding in the edited files.

And finally, adds a small blurb about how to subscribe an email address to a mailing list.
