### PR TITLE
Add support for passing Salesforce OAuth access_token

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,15 +8,17 @@ Add the following to your Gemfile
 
 === Authentication
 
-The client will authenticate before performing other API calls, but you can manually authenticate as well
+In order to use this client, an access token retrieved from Salesforce OAuth must be specified. See
+the [authetication documentation on developer.pardot.com](https://developer.pardot.com/kb/authentication/) for more information.
 
   require "ruby-pardot"
 
-  client = Pardot::Client.new email, password, user_key
+  version = 3 # or 4
+  access_token = '<access_token>' # Retrieve an access token from Salesforce using OAuth
+  business_unit_id = '<business_unit_id>' # Specify the Business Unit ID of the account to access
+  client = Pardot::Client.new nil, nil, nil, version, access_token, business_unit_id
   
-  # will raise a Pardot::ResponseError if login fails
-  # will raise a Pardot::NetError if the http call fails
-  client.authenticate
+Usage of the username, password, and API key authentication is deprecated and will be removed in an upcoming release.
   
 === Object Types
 

--- a/lib/pardot/authentication.rb
+++ b/lib/pardot/authentication.rb
@@ -1,17 +1,26 @@
 module Pardot
   module Authentication
-    
+
+    # @deprecated Use of username and password authentication is deprecated.
     def authenticate
+      raise "Authentication not available when using Salesforce access token. See https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm for more information." if using_salesforce_access_token?
+      warn "[DEPRECATION] Use of username and password authentication is deprecated in favor of Salesforce OAuth. See https://developer.pardot.com/kb/authentication/ for more information."
       resp = post "login", nil, nil, nil, :email => @email, :password => @password, :user_key => @user_key
       update_version(resp["version"]) if resp && resp["version"]
       @api_key = resp && resp["api_key"]
     end
     
     def authenticated?
-      @api_key != nil
+      @api_key != nil || @salesforce_access_token != nil
+    end
+
+    def using_salesforce_access_token?
+      @salesforce_access_token != nil
     end
     
     def reauthenticate
+      raise "Reauthentication not available when using Salesforce access token. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/oauth_refresh_token_flow.htm for more information." if using_salesforce_access_token?
+      warn "[DEPRECATION] Use Salesforce OAuth to refresh the Salesforce access token. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/oauth_refresh_token_flow.htm for more information."
       @api_key = nil
       authenticate
     end

--- a/lib/pardot/client.rb
+++ b/lib/pardot/client.rb
@@ -21,13 +21,23 @@ module Pardot
     include Objects::Visits
     include Objects::VisitorActivities
 
-    attr_accessor :email, :password, :user_key, :api_key, :version, :format
+    attr_accessor :email, :password, :user_key, :api_key, :version, :salesforce_access_token, :business_unit_id, :format
 
-    def initialize email, password, user_key, version = 3
+    # @deprecated Arguments email, password and user_key are deprecated. Use salesforce_access_token with Salesforce OAuth. 
+    def initialize email = nil, password = nil, user_key = nil, version = 3, salesforce_access_token = nil, business_unit_id = nil
+      if !(email.nil? || password.nil? || user_key.nil?) then
+        warn "[DEPRECATION] Use of username and password authentication is deprecated in favor of Salesforce OAuth. See https://developer.pardot.com/kb/authentication/ for more information."
+      end
+
+      raise "business_unit_id required when using Salesforce access_token" if !salesforce_access_token.nil? && business_unit_id.nil?
+      raise "Invalid business_unit_id value. Expected ID to start with '0Uv' and be length of 18 characters." if !business_unit_id.nil? && (!business_unit_id.start_with?('0Uv') || business_unit_id.length != 18)
+
       @email = email
       @password = password
       @user_key = user_key
       @version = version
+      @salesforce_access_token = salesforce_access_token
+      @business_unit_id = business_unit_id
 
       @format = "simple"
     end

--- a/lib/pardot/error.rb
+++ b/lib/pardot/error.rb
@@ -2,6 +2,7 @@ module Pardot
   class Error < StandardError; end
   class NetError < Error; end
   class ExpiredApiKeyError < Error; end
+  class AccessTokenExpiredError < Error; end
 
   class ResponseError < Error
     def initialize(res)

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = "1.3.2"
+  VERSION = "1.4.0"
 end

--- a/spec/pardot/authentication_spec.rb
+++ b/spec/pardot/authentication_spec.rb
@@ -5,6 +5,32 @@ describe Pardot::Authentication do
   def create_client
     @client = Pardot::Client.new "user@test.com", "foo", "bar"
   end
+
+  def create_client_using_salesforce_access_token
+    @client = Pardot::Client.new nil, nil, nil, 3, "access_token_value", '0Uv000000000001CAA'
+  end
+
+  describe "authenticate with Salesforce access_token" do
+    before do
+      @client = create_client_using_salesforce_access_token
+    end
+
+    it "raises error when calling authenticate" do
+      expect{ @client.authenticate }.to raise_error.with_message(/Authentication not available when using Salesforce access token/)
+    end
+
+    it "raises error when calling reauthenticate" do
+      expect{ @client.reauthenticate }.to raise_error.with_message(/Reauthentication not available when using Salesforce access token/)
+    end
+
+    it "returns true for authenticated" do
+      expect(@client.authenticated?).to eq(true)
+    end
+
+    it "returns true for using_salesforce_access_token" do
+      expect(@client.using_salesforce_access_token?).to eq(true)
+    end
+  end
   
   describe "authenticate" do
     
@@ -45,6 +71,13 @@ describe Pardot::Authentication do
       verifyBody
     end
     
+    it "returns false for using_salesforce_access_token" do
+      expect(@client.using_salesforce_access_token?).to eq(false)
+
+      authenticate
+      expect(@client.using_salesforce_access_token?).to eq(false)
+      verifyBody
+    end
   end
 
   describe "authenticateV4" do

--- a/spec/pardot/client_spec.rb
+++ b/spec/pardot/client_spec.rb
@@ -5,6 +5,33 @@ describe Pardot::Client do
   def create_client
     @client = Pardot::Client.new "user@test.com", "foo", "bar"
   end
+
+  describe "client with Salesforce access_token" do
+
+    it "should set properties" do
+      @client = Pardot::Client.new nil, nil, nil, 3, 'access_token_value', '0Uv000000000001CAA'
+      expect(@client.email).to eq(nil)
+      expect(@client.password).to eq(nil)
+      expect(@client.user_key).to eq(nil)
+      expect(@client.api_key).to eq(nil)
+      expect(@client.version).to eq(3)
+      expect(@client.salesforce_access_token).to eq('access_token_value')
+      expect(@client.business_unit_id).to eq('0Uv000000000001CAA')
+      expect(@client.format).to eq("simple")
+    end
+
+    it "raises error with nil business_unit_id" do
+      expect{ Pardot::Client.new nil, nil, nil, 3, "access_token_value", nil }.to raise_error.with_message(/business_unit_id required when using Salesforce access_token/)
+    end
+
+    it "raises error with invalid business_unit_id due to length" do
+      expect{ Pardot::Client.new nil, nil, nil, 3, "access_token_value", '0Uv1234567890' }.to raise_error.with_message(/Invalid business_unit_id value. Expected ID to start with '0Uv' and be length of 18 characters./)
+    end
+
+    it "raises error with invalid business_unit_id due to invalid prefix" do
+      expect{ Pardot::Client.new nil, nil, nil, 3, "access_token_value", '001000000000001AAA' }.to raise_error.with_message(/Invalid business_unit_id value. Expected ID to start with '0Uv' and be length of 18 characters./)
+    end
+  end
   
   describe "client" do
     after do

--- a/spec/pardot/http_spec.rb
+++ b/spec/pardot/http_spec.rb
@@ -19,7 +19,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/3/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
 
       expect(lambda { get }).to raise_error(Pardot::ResponseError)
@@ -33,7 +33,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/3/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       expect(@client).to receive(:handle_expired_api_key)
       get
@@ -49,7 +49,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/3/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       expect(lambda { post }).to raise_error(Pardot::ResponseError)
     end
@@ -62,7 +62,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/3/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       expect(@client).to receive(:handle_expired_api_key)
       post
@@ -79,7 +79,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_get "/api/foo/version/4/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       expect(lambda { get }).to raise_error(Pardot::ResponseError)
     end
@@ -92,7 +92,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_get "/api/foo/version/4/bar?format=simple",
-               %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+               %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       expect(@client).to receive(:handle_expired_api_key)
       get
@@ -109,7 +109,7 @@ describe Pardot::Http do
     
     it "should notice errors and raise them as Pardot::ResponseError" do
       fake_post "/api/foo/version/4/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Login failed</err>\n</rsp>\n)
       
       expect(lambda { post }).to raise_error(Pardot::ResponseError)
     end
@@ -122,7 +122,7 @@ describe Pardot::Http do
     
     it "should call handle_expired_api_key when the api key expires" do
       fake_post "/api/foo/version/4/bar?format=simple",
-                %(?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
+                %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="fail" version="1.0">\n   <err code="15">Invalid API key or user key</err>\n</rsp>\n)
       
       expect(@client).to receive(:handle_expired_api_key)
       post

--- a/spec/pardot/objects/custom_fields_spec.rb
+++ b/spec/pardot/objects/custom_fields_spec.rb
@@ -1,58 +1,54 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::CustomFields do
-  
-  before do
-    @client = create_client
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
+    
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>1</total_results>
+                <customField>
+                  <created_at>2019-11-26 13:40:37</created_at>
+                  <crm_id null="true" />
+                  <field_id>CustomObject1574793618883</field_id>
+                  <id>8932</id>
+                  <is_record_multiple_responses>false</is_record_multiple_responses>
+                  <is_use_values>false</is_use_values>
+                  <name>Ω≈ç√∫˜µ≤≥÷</name>
+                  <type>Text</type>
+                  <type_id>1</type_id>
+                  <updated_at>2019-11-26 13:40:37</updated_at>
+              </customField>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/customField/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.custom_fields.query(:id_greater_than => 200)).to eq({"total_results" => 1, 
+            "customField"=>
+              {
+                "id"=>"8932",
+                "name"=>"Ω≈ç√∫˜µ≤≥÷",
+                "field_id"=>"CustomObject1574793618883",
+                "type"=>"Text",
+                "type_id"=>"1",
+                "crm_id"=>{"null"=>"true"},
+                "is_record_multiple_responses"=>"false",
+                "is_use_values"=>"false",
+                "created_at"=>"2019-11-26 13:40:37",
+                "updated_at"=>"2019-11-26 13:40:37"
+              }
+            })
+            assert_authorization_header auth_manager
+        end
+        
+      end
+    end
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>1</total_results>
-            <customField>
-              <created_at>2019-11-26 13:40:37</created_at>
-              <crm_id null="true" />
-              <field_id>CustomObject1574793618883</field_id>
-              <id>8932</id>
-              <is_record_multiple_responses>false</is_record_multiple_responses>
-              <is_use_values>false</is_use_values>
-              <name>Ω≈ç√∫˜µ≤≥÷</name>
-              <type>Text</type>
-              <type_id>1</type_id>
-              <updated_at>2019-11-26 13:40:37</updated_at>
-          </customField>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/customField/version/3/do/query?id_greater_than=200&format=simple", sample_results
-      
-      expect(@client.custom_fields.query(:id_greater_than => 200)).to eq({"total_results" => 1, 
-        "customField"=>
-          {
-            "id"=>"8932",
-            "name"=>"Ω≈ç√∫˜µ≤≥÷",
-            "field_id"=>"CustomObject1574793618883",
-            "type"=>"Text",
-            "type_id"=>"1",
-            "crm_id"=>{"null"=>"true"},
-            "is_record_multiple_responses"=>"false",
-            "is_use_values"=>"false",
-            "created_at"=>"2019-11-26 13:40:37",
-            "updated_at"=>"2019-11-26 13:40:37"
-          }
-        })
-      assert_authorization_header
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/emails_spec.rb
+++ b/spec/pardot/objects/emails_spec.rb
@@ -1,39 +1,35 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Emails do
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
 
-  before do
-    @client = create_client
+      def sample_response
+        %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+          <email>
+            <name>My Email</name>
+          </email>
+        </rsp>)
+      end
+
+      it "should take in the email ID" do
+        fake_get "/api/email/version/3/do/read/id/12?format=simple", sample_response
+        expect(client.emails.read_by_id(12)).to eq({"name" => "My Email"})
+        assert_authorization_header auth_manager
+      end
+
+      it 'should send to a prospect' do
+        fake_post '/api/email/version/3/do/send/prospect_id/42?campaign_id=765&email_template_id=86&format=simple', sample_response
+        expect(client.emails.send_to_prospect(42, :campaign_id => 765, :email_template_id => 86)).to eq({"name" => "My Email"})
+        assert_authorization_header auth_manager
+      end
+
+      it 'should send to a list' do
+        fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids%5B%5D=235&campaign_id=654&format=simple', sample_response
+        expect(client.emails.send_to_list(:email_template_id => 200, 'list_ids[]' => 235, :campaign_id => 654)).to eq({"name" => "My Email"})
+        assert_authorization_header auth_manager
+      end
+    end
   end
-
-  def sample_response
-    %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-      <email>
-        <name>My Email</name>
-      </email>
-    </rsp>)
-  end
-
-  before do
-    @client = create_client
-  end
-
-  it "should take in the email ID" do
-    fake_get "/api/email/version/3/do/read/id/12?format=simple", sample_response
-    expect(@client.emails.read_by_id(12)).to eq({"name" => "My Email"})
-    assert_authorization_header
-  end
-
-  it 'should send to a prospect' do
-    fake_post '/api/email/version/3/do/send/prospect_id/42?campaign_id=765&email_template_id=86&format=simple', sample_response
-    expect(@client.emails.send_to_prospect(42, :campaign_id => 765, :email_template_id => 86)).to eq({"name" => "My Email"})
-    assert_authorization_header
-  end
-
-  it 'should send to a list' do
-    fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids%5B%5D=235&campaign_id=654&format=simple', sample_response
-    expect(@client.emails.send_to_list(:email_template_id => 200, 'list_ids[]' => 235, :campaign_id => 654)).to eq({"name" => "My Email"})
-    assert_authorization_header
-  end
-
 end

--- a/spec/pardot/objects/emails_spec.rb
+++ b/spec/pardot/objects/emails_spec.rb
@@ -31,7 +31,7 @@ describe Pardot::Objects::Emails do
   end
 
   it 'should send to a list' do
-    fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids[]=235&campaign_id=654&format=simple', sample_response
+    fake_post '/api/email/version/3/do/send?email_template_id=200&list_ids%5B%5D=235&campaign_id=654&format=simple', sample_response
     expect(@client.emails.send_to_list(:email_template_id => 200, 'list_ids[]' => 235, :campaign_id => 654)).to eq({"name" => "My Email"})
     assert_authorization_header
   end

--- a/spec/pardot/objects/lists_spec.rb
+++ b/spec/pardot/objects/lists_spec.rb
@@ -1,42 +1,38 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
-describe Pardot::Objects::Lists do
-  
-  before do
-    @client = create_client
+describe Pardot::Objects::Lists do  
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
+
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <list>
+                <name>Asdf List</name>
+              </list>
+              <list>
+                <name>Qwerty List</name>
+              </list>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/list/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.lists.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "list"=>[
+              {"name"=>"Asdf List"}, 
+              {"name"=>"Qwerty List"}
+            ]})
+          assert_authorization_header auth_manager
+        end
+        
+      end
+    end
   end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <list>
-            <name>Asdf List</name>
-          </list>
-          <list>
-            <name>Qwerty List</name>
-          </list>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/list/version/3/do/query?id_greater_than=200&format=simple", sample_results
-      
-      expect(@client.lists.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "list"=>[
-          {"name"=>"Asdf List"}, 
-          {"name"=>"Qwerty List"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
 end

--- a/spec/pardot/objects/opportunities_spec.rb
+++ b/spec/pardot/objects/opportunities_spec.rb
@@ -1,66 +1,61 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Opportunities do
-  
-  before do
-    @client = create_client
-  end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <opportunity>
-            <name>Jim</name>
-            <type>Great</type>
-          </opportunity>
-          <opportunity>
-            <name>Sue</name>
-            <type>Good</type>
-          </opportunity>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/opportunity/version/3/do/query?id_greater_than=200&format=simple", sample_results
-      
-      expect(@client.opportunities.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "opportunity"=>[
-          {"type"=>"Great", "name"=>"Jim"}, 
-          {"type"=>"Good", "name"=>"Sue"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "create_by_email" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <opportunity>
-          <name>Jim</name>
-          <type>Good</type>
-        </opportunity>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/opportunity/version/3/do/create/prospect_email/user@test.com?type=Good&format=simple&name=Jim", sample_results
-      
-      expect(@client.opportunities.create_by_email("user@test.com", :name => "Jim", :type => "Good")).to eq({"name"=>"Jim", "type"=>"Good"})
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
 
-      assert_authorization_header
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <opportunity>
+                <name>Jim</name>
+                <type>Great</type>
+              </opportunity>
+              <opportunity>
+                <name>Sue</name>
+                <type>Good</type>
+              </opportunity>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/opportunity/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.opportunities.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "opportunity"=>[
+              {"type"=>"Great", "name"=>"Jim"}, 
+              {"type"=>"Good", "name"=>"Sue"}
+            ]})
+          assert_authorization_header auth_manager
+        end
+        
+      end
+      
+      describe "create_by_email" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <opportunity>
+              <name>Jim</name>
+              <type>Good</type>
+            </opportunity>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/opportunity/version/3/do/create/prospect_email/user@test.com?type=Good&format=simple&name=Jim", sample_results
+          
+          expect(client.opportunities.create_by_email("user@test.com", :name => "Jim", :type => "Good")).to eq({"name"=>"Jim", "type"=>"Good"})
+
+          assert_authorization_header auth_manager
+        end
+      end
     end
-    
   end
-  
 end

--- a/spec/pardot/objects/prospect_accounts_spec.rb
+++ b/spec/pardot/objects/prospect_accounts_spec.rb
@@ -2,79 +2,81 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::ProspectAccounts do
 
-  before do
-    @client = create_client
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
+
+      describe "query" do
+
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <prospectAccount>
+                <name>Spaceships R Us</name>
+              </prospectAccount>
+              <prospectAccount>
+                <name>Monsters Inc</name>
+              </prospectAccount>
+            </result>
+          </rsp>)
+        end
+
+        it "should take in some arguments and respond with valid items" do
+          fake_get "/api/prospectAccount/version/3/do/query?assigned=true&format=simple", sample_results
+
+          expect(client.prospect_accounts.query(:assigned => true)).to eq({'total_results' => 2,
+            'prospectAccount'=>[
+              {'name'=>'Spaceships R Us'},
+              {'name'=>'Monsters Inc'}
+            ]})
+          assert_authorization_header auth_manager
+        end
+
+      end
+
+      describe 'read' do
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <prospectAccount>
+              <id>1234</id>
+              <name>SupaDupaPanda</name>
+            </prospectAccount>
+            </rsp>)
+        end
+
+        it 'should return a valid account' do
+          fake_post '/api/prospectAccount/version/3/do/read/id/1234?assigned=true&format=simple', sample_results
+
+          expect(client.prospect_accounts.read('1234', :assigned => true)).to eq({'id' => '1234', 'name' => 'SupaDupaPanda' })
+          assert_authorization_header auth_manager
+        end
+
+      end
+
+
+      describe 'create' do
+
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <prospectAccount>
+              <name>SuperPanda</name>
+            </prospectAccount>
+          </rsp>)
+        end
+
+        it 'should return the prospect account' do
+          fake_post '/api/prospectAccount/version/3/do/create?format=simple&name=SuperPanda', sample_results
+
+          expect(client.prospect_accounts.create(:name => 'SuperPanda')).to eq({"name"=>"SuperPanda"})
+          assert_authorization_header auth_manager
+        end
+
+      end
+
+    end
   end
-
-  describe "query" do
-
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <prospectAccount>
-            <name>Spaceships R Us</name>
-          </prospectAccount>
-          <prospectAccount>
-            <name>Monsters Inc</name>
-          </prospectAccount>
-        </result>
-      </rsp>)
-    end
-
-    it "should take in some arguments and respond with valid items" do
-      fake_get "/api/prospectAccount/version/3/do/query?assigned=true&format=simple", sample_results
-
-      expect(@client.prospect_accounts.query(:assigned => true)).to eq({'total_results' => 2,
-        'prospectAccount'=>[
-          {'name'=>'Spaceships R Us'},
-          {'name'=>'Monsters Inc'}
-        ]})
-      assert_authorization_header
-    end
-
-  end
-
-  describe 'read' do
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <prospectAccount>
-          <id>1234</id>
-          <name>SupaDupaPanda</name>
-        </prospectAccount>
-        </rsp>)
-    end
-
-    it 'should return a valid account' do
-      fake_post '/api/prospectAccount/version/3/do/read/id/1234?assigned=true&format=simple', sample_results
-
-      expect(@client.prospect_accounts.read('1234', :assigned => true)).to eq({'id' => '1234', 'name' => 'SupaDupaPanda' })
-      assert_authorization_header
-    end
-
-  end
-
-
-  describe 'create' do
-
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <prospectAccount>
-          <name>SuperPanda</name>
-        </prospectAccount>
-      </rsp>)
-    end
-
-    it 'should return the prospect account' do
-      fake_post '/api/prospectAccount/version/3/do/create?format=simple&name=SuperPanda', sample_results
-
-      expect(@client.prospect_accounts.create(:name => 'SuperPanda')).to eq({"name"=>"SuperPanda"})
-      assert_authorization_header
-    end
-
-  end
-
 end

--- a/spec/pardot/objects/prospects_spec.rb
+++ b/spec/pardot/objects/prospects_spec.rb
@@ -2,61 +2,62 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Prospects do
   
-  before do
-    @client = create_client
-  end
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
   
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <prospect>
-            <first_name>Jim</first_name>
-            <last_name>Smith</last_name>
-          </prospect>
-          <prospect>
-            <first_name>Sue</first_name>
-            <last_name>Green</last_name>
-          </prospect>
-        </result>
-      </rsp>)
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/prospect/version/3/do/query?assigned=true&format=simple", sample_results
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <prospect>
+                <first_name>Jim</first_name>
+                <last_name>Smith</last_name>
+              </prospect>
+              <prospect>
+                <first_name>Sue</first_name>
+                <last_name>Green</last_name>
+              </prospect>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/prospect/version/3/do/query?assigned=true&format=simple", sample_results
+          
+          expect(client.prospects.query(:assigned => true)).to eq({"total_results" => 2, 
+            "prospect"=>[
+              {"last_name"=>"Smith", "first_name"=>"Jim"}, 
+              {"last_name"=>"Green", "first_name"=>"Sue"}
+            ]})
+            assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.prospects.query(:assigned => true)).to eq({"total_results" => 2, 
-        "prospect"=>[
-          {"last_name"=>"Smith", "first_name"=>"Jim"}, 
-          {"last_name"=>"Green", "first_name"=>"Sue"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "create" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <prospect>
-          <first_name>Jim</first_name>
-          <last_name>Smith</last_name>
-        </prospect>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/prospect/version/3/do/create/email/user%40test.com?first_name=Jim&format=simple", sample_results
+      describe "create" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <prospect>
+              <first_name>Jim</first_name>
+              <last_name>Smith</last_name>
+            </prospect>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/prospect/version/3/do/create/email/user%40test.com?first_name=Jim&format=simple", sample_results
 
-      expect(@client.prospects.create("user@test.com", :first_name => "Jim")).to eq({"last_name"=>"Smith", "first_name"=>"Jim"})
-      assert_authorization_header
+          expect(client.prospects.create("user@test.com", :first_name => "Jim")).to eq({"last_name"=>"Smith", "first_name"=>"Jim"})
+          assert_authorization_header auth_manager
+        end
+        
+      end
     end
-    
   end
-  
 end

--- a/spec/pardot/objects/users_spec.rb
+++ b/spec/pardot/objects/users_spec.rb
@@ -1,65 +1,62 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Users do
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
   
-  before do
-    @client = create_client
-  end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <user>
-            <email>user@test.com</email>
-            <first_name>Jim</first_name>
-          </user>
-          <user>
-            <email>user@example.com</email>
-            <first_name>Sue</first_name>
-          </user>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/user/version/3/do/query?id_greater_than=200&format=simple", sample_results
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <user>
+                <email>user@test.com</email>
+                <first_name>Jim</first_name>
+              </user>
+              <user>
+                <email>user@example.com</email>
+                <first_name>Sue</first_name>
+              </user>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/user/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.users.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "user"=>[
+              {"email"=>"user@test.com", "first_name"=>"Jim"}, 
+              {"email"=>"user@example.com", "first_name"=>"Sue"}
+            ]})
+            assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.users.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "user"=>[
-          {"email"=>"user@test.com", "first_name"=>"Jim"}, 
-          {"email"=>"user@example.com", "first_name"=>"Sue"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "read_by_email" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <user>
-          <email>user@example.com</email>
-          <first_name>Sue</first_name>
-        </user>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/user/version/3/do/read/email/user@test.com?format=simple", sample_results
+      describe "read_by_email" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <user>
+              <email>user@example.com</email>
+              <first_name>Sue</first_name>
+            </user>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/user/version/3/do/read/email/user@test.com?format=simple", sample_results
+          
+          expect(client.users.read_by_email("user@test.com")).to eq({"email"=>"user@example.com", "first_name"=>"Sue"})
+          assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.users.read_by_email("user@test.com")).to eq({"email"=>"user@example.com", "first_name"=>"Sue"})
-      assert_authorization_header
     end
-    
   end
-  
 end

--- a/spec/pardot/objects/visitor_activities_spec.rb
+++ b/spec/pardot/objects/visitor_activities_spec.rb
@@ -2,64 +2,62 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::VisitorActivities do
   
-  before do
-    @client = create_client
-  end
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
   
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visitorActivity>
-            <type_name>Read</type_name>
-            <details>Some details</details>
-          </visitorActivity>
-          <visitorActivity>
-            <type_name>Write</type_name>
-            <details>More details</details>
-          </visitorActivity>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visitorActivity/version/3/do/query?id_greater_than=200&format=simple", sample_results
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <visitorActivity>
+                <type_name>Read</type_name>
+                <details>Some details</details>
+              </visitorActivity>
+              <visitorActivity>
+                <type_name>Write</type_name>
+                <details>More details</details>
+              </visitorActivity>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/visitorActivity/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.visitor_activities.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "visitorActivity"=>[
+              {"type_name"=>"Read", "details"=>"Some details"}, 
+              {"type_name"=>"Write", "details"=>"More details"}
+            ]})
+            assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visitor_activities.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "visitorActivity"=>[
-          {"type_name"=>"Read", "details"=>"Some details"}, 
-          {"type_name"=>"Write", "details"=>"More details"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "read" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visitorActivity>
-          <type_name>Write</type_name>
-          <details>More details</details>
-        </visitorActivity>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/visitorActivity/version/3/do/read/id/10?format=simple", sample_results
+      describe "read" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <visitorActivity>
+              <type_name>Write</type_name>
+              <details>More details</details>
+            </visitorActivity>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/visitorActivity/version/3/do/read/id/10?format=simple", sample_results
+          
+          expect(client.visitor_activities.read(10)).to eq({"details"=>"More details", "type_name"=>"Write"})
+          assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visitor_activities.read(10)).to eq({"details"=>"More details", "type_name"=>"Write"})
-      assert_authorization_header
     end
-    
   end
-  
 end

--- a/spec/pardot/objects/visitors_spec.rb
+++ b/spec/pardot/objects/visitors_spec.rb
@@ -2,64 +2,61 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Visitors do
   
-  before do
-    @client = create_client
-  end
-  
-  describe "query" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visitor>
-            <browser>Firefox</browser>
-            <language>en</language>
-          </visitor>
-          <visitor>
-            <browser>Chrome</browser>
-            <language>es</language>
-          </visitor>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visitor/version/3/do/query?id_greater_than=200&format=simple", sample_results
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
+      describe "query" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <visitor>
+                <browser>Firefox</browser>
+                <language>en</language>
+              </visitor>
+              <visitor>
+                <browser>Chrome</browser>
+                <language>es</language>
+              </visitor>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/visitor/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.visitors.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "visitor"=>[
+              {"browser"=>"Firefox", "language"=>"en"}, 
+              {"browser"=>"Chrome", "language"=>"es"}
+            ]})
+          assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visitors.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "visitor"=>[
-          {"browser"=>"Firefox", "language"=>"en"}, 
-          {"browser"=>"Chrome", "language"=>"es"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "assign" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visitor>
-          <browser>Chrome</browser>
-          <language>es</language>
-        </visitor>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/visitor/version/3/do/assign/id/10?type=Good&format=simple&name=Jim", sample_results
+      describe "assign" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <visitor>
+              <browser>Chrome</browser>
+              <language>es</language>
+            </visitor>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/visitor/version/3/do/assign/id/10?type=Good&format=simple&name=Jim", sample_results
+          
+          expect(client.visitors.assign(10, :name => "Jim", :type => "Good")).to eq({"browser"=>"Chrome", "language"=>"es"})
+          assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visitors.assign(10, :name => "Jim", :type => "Good")).to eq({"browser"=>"Chrome", "language"=>"es"})
-      assert_authorization_header
     end
-    
   end
-  
 end

--- a/spec/pardot/objects/visits_spec.rb
+++ b/spec/pardot/objects/visits_spec.rb
@@ -2,64 +2,61 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Pardot::Objects::Visits do
   
-  before do
-    @client = create_client
-  end
-  
-  describe "query" do
+  create_auth_managers.each do |auth_manager|
+    context auth_manager.test_name_suffix do
+      let(:client) { auth_manager.create_client }
+      describe "query" do
     
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
-        <result>
-          <total_results>2</total_results>
-          <visit>
-            <duration_in_seconds>50</duration_in_seconds>
-            <visitor_page_view_count>3</visitor_page_view_count>
-          </visit>
-          <visit>
-            <duration_in_seconds>10</duration_in_seconds>
-            <visitor_page_view_count>1</visitor_page_view_count>
-          </visit>
-        </result>
-      </rsp>)
-    end
-    
-    before do
-      @client = create_client
-    end
-    
-    it "should take in some arguments" do
-      fake_get "/api/visit/version/3/do/query?id_greater_than=200&format=simple", sample_results
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>\n<rsp stat="ok" version="1.0">
+            <result>
+              <total_results>2</total_results>
+              <visit>
+                <duration_in_seconds>50</duration_in_seconds>
+                <visitor_page_view_count>3</visitor_page_view_count>
+              </visit>
+              <visit>
+                <duration_in_seconds>10</duration_in_seconds>
+                <visitor_page_view_count>1</visitor_page_view_count>
+              </visit>
+            </result>
+          </rsp>)
+        end
+        
+        it "should take in some arguments" do
+          fake_get "/api/visit/version/3/do/query?id_greater_than=200&format=simple", sample_results
+          
+          expect(client.visits.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
+            "visit"=>[
+              {"duration_in_seconds"=>"50", "visitor_page_view_count"=>"3"}, 
+              {"duration_in_seconds"=>"10", "visitor_page_view_count"=>"1"}
+            ]})
+            assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visits.query(:id_greater_than => 200)).to eq({"total_results" => 2, 
-        "visit"=>[
-          {"duration_in_seconds"=>"50", "visitor_page_view_count"=>"3"}, 
-          {"duration_in_seconds"=>"10", "visitor_page_view_count"=>"1"}
-        ]})
-      assert_authorization_header
-    end
-    
-  end
-  
-  describe "read" do
-    
-    def sample_results
-      %(<?xml version="1.0" encoding="UTF-8"?>
-      <rsp stat="ok" version="1.0">
-        <visit>
-          <duration_in_seconds>10</duration_in_seconds>
-          <visitor_page_view_count>1</visitor_page_view_count>
-        </visit>
-      </rsp>)
-    end
-    
-    it "should return the prospect" do
-      fake_post "/api/visit/version/3/do/read/id/10?format=simple", sample_results
+      describe "read" do
+        
+        def sample_results
+          %(<?xml version="1.0" encoding="UTF-8"?>
+          <rsp stat="ok" version="1.0">
+            <visit>
+              <duration_in_seconds>10</duration_in_seconds>
+              <visitor_page_view_count>1</visitor_page_view_count>
+            </visit>
+          </rsp>)
+        end
+        
+        it "should return the prospect" do
+          fake_post "/api/visit/version/3/do/read/id/10?format=simple", sample_results
+          
+          expect(client.visits.read(10)).to eq({"visitor_page_view_count"=>"1", "duration_in_seconds"=>"10"})
+          assert_authorization_header auth_manager
+        end
+        
+      end
       
-      expect(@client.visits.read(10)).to eq({"visitor_page_view_count"=>"1", "duration_in_seconds"=>"10"})
-      assert_authorization_header
     end
-    
   end
-  
 end

--- a/spec/support/client_support.rb
+++ b/spec/support/client_support.rb
@@ -1,6 +1,51 @@
 
 def create_client
-  @client = Pardot::Client.new "user@test.com", "foo", "bar"
-  @client.api_key = "my_api_key"
-  @client
+  #@client = Pardot::Client.new "user@test.com", "foo", "bar"
+  #@client.api_key = "my_api_key"
+  #@client
+end
+
+def create_auth_managers
+  [UsernamePasswordAuthManager.new, SalesforceAccessTokenAuthManager.new]
+end
+
+class UsernamePasswordAuthManager
+
+  attr_accessor :test_name_suffix, :expected_authorization_header
+
+  def initialize
+    @test_name_suffix = 'With UsernamePassword Auth'
+    @expected_authorization_header = 'Pardot api_key=my_api_key, user_key=bar'
+  end
+
+  def create_client
+    client = Pardot::Client.new "user@test.com", "foo", "bar"
+    client.api_key = "my_api_key"
+    client
+  end
+
+  def has_business_unit_id_header?
+    false
+  end
+
+end
+
+class SalesforceAccessTokenAuthManager
+
+  attr_accessor :test_name_suffix, :expected_authorization_header, :expected_business_unit_id_header
+
+  def initialize
+    @test_name_suffix = 'With Salesforce OAuth'
+    @expected_authorization_header = 'Bearer access_token_value'
+    @expected_business_unit_id_header = '0Uv000000000001CAA'
+  end
+
+  def create_client
+    Pardot::Client.new nil, nil, nil, 3, 'access_token_value', '0Uv000000000001CAA'
+  end
+
+  def has_business_unit_id_header?
+    false
+  end
+
 end

--- a/spec/support/client_support.rb
+++ b/spec/support/client_support.rb
@@ -1,10 +1,4 @@
 
-def create_client
-  #@client = Pardot::Client.new "user@test.com", "foo", "bar"
-  #@client.api_key = "my_api_key"
-  #@client
-end
-
 def create_auth_managers
   [UsernamePasswordAuthManager.new, SalesforceAccessTokenAuthManager.new]
 end

--- a/spec/support/fakeweb.rb
+++ b/spec/support/fakeweb.rb
@@ -13,6 +13,9 @@ def fake_authenticate client, api_key
   client.api_key = api_key
 end
 
-def assert_authorization_header
-  expect(FakeWeb.last_request[:authorization]).to eq('Pardot api_key=my_api_key, user_key=bar')
+def assert_authorization_header auth_manager
+  expect(FakeWeb.last_request[:authorization]).to eq(auth_manager.expected_authorization_header)
+  if auth_manager.has_business_unit_id_header? then
+    expect(FakeWeb.last_request['Business-Unit-Id']).to eq(auth_manager.expected_business_unit_id_header)
+  end
 end


### PR DESCRIPTION
This PR adds support adding Salesforce OAuth access_token for authentication instead of username, password and API key. This change is backwards compatible with previous versions however warning messages will be written to the logs. All of the tests have been updated to run under both authentication methods. In a future iteration, the client will be updated to remove the username, password and API key and only allow Salesforce OAuth access tokens.

This PR does not include any means of acquiring an Salesforce OAuth access_token; the expectation is that the application will use [Salesforce guidance](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm) to acquire the token before calling into the Ruby client code.

For more information on how Authentication is changing, see the [Authentication page in the Pardot Developer Docs](https://developer.pardot.com/kb/authentication/).