### PR TITLE
update crack to remove dependency on safe_yaml which won't run in Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-pardot (1.4.1)
+    ruby-pardot (1.4.2)
       crack (= 0.4.5)
       httparty (= 0.18.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,14 @@ PATH
   remote: .
   specs:
     ruby-pardot (1.4.1)
-      crack (= 0.4.4)
+      crack (= 0.4.5)
       httparty (= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    crack (0.4.4)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.4.4)
     fakeweb (1.3.0)
     httparty (0.18.1)
@@ -18,6 +19,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
     multi_xml (0.6.0)
+    rexml (3.2.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,14 +10,14 @@ GEM
   specs:
     crack (0.4.5)
       rexml
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     fakeweb (1.3.0)
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
+    mime-types-data (3.2023.0218.1)
     multi_xml (0.6.0)
     rexml (3.2.5)
     rspec (3.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,13 @@ PATH
   remote: .
   specs:
     ruby-pardot (1.4.1)
-      crack (= 0.4.3)
+      crack (= 0.4.4)
       httparty (= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.4)
     diff-lcs (1.4.4)
     fakeweb (1.3.0)
     httparty (0.18.1)
@@ -32,7 +31,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    safe_yaml (1.0.5)
 
 PLATFORMS
   ruby
@@ -44,4 +42,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   2.2.7
+   2.3.26

--- a/lib/pardot/version.rb
+++ b/lib/pardot/version.rb
@@ -1,3 +1,3 @@
 module Pardot
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-pardot"
 
-  s.add_dependency 'crack', '0.4.3'
+  s.add_dependency 'crack', '0.4.4'
   s.add_dependency 'httparty', '0.18.1'
 
   s.add_development_dependency "bundler", ">= 1.10"

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-pardot"
 
-  s.add_dependency 'crack', '0.4.4'
+  s.add_dependency 'crack', '0.4.5'
   s.add_dependency 'httparty', '0.18.1'
 
   s.add_development_dependency "bundler", ">= 1.10"


### PR DESCRIPTION
crack 0.4.3 depends on safe_yaml which hasn't been updated to run in Ruby 3. The simplest way to get ruby-pardot working in Ruby 3 is just to update the crack dependency.

I've checked that the tests pass in Ruby 3.1.2, and that they continue to pass in Ruby 2.7.6 after making these changes.

This PR supersedes #60.