### PR TITLE
Make base_uri changeable with environment variables

### DIFF
--- a/lib/pardot/client.rb
+++ b/lib/pardot/client.rb
@@ -1,7 +1,7 @@
 module Pardot
   class Client
     include HTTParty
-    base_uri 'https://pi.pardot.com'
+    base_uri ENV.fetch('PARDOT_URL', 'https://pi.pardot.com')
     format :xml
 
     include Authentication

--- a/spec/pardot/client_spec.rb
+++ b/spec/pardot/client_spec.rb
@@ -7,6 +7,28 @@ describe Pardot::Client do
     @client = Pardot::Client.new 'user@test.com', 'foo', 'bar'
   end
 
+  describe '#base_uri' do
+    context 'without PARDOT_URL' do
+      before do
+        ENV.delete('PARDOT_URL')
+      end
+
+      it 'return default value' do
+        expect(Pardot::Client.base_uri).to eq('https://pi.pardot.com')
+      end
+    end
+
+    context 'with PARDOT_URL' do
+      before do
+        ENV['PARDOT_URL'] = 'https://pi.demo.pardot.com'
+      end
+
+      it 'return ENV value' do
+        expect(Pardot::Client.base_uri).to eq('https://pi.pardot.com')
+      end
+    end
+  end
+
   describe 'client with Salesforce access_token' do
     it 'should set properties' do
       @client = Pardot::Client.new nil, nil, nil, 3, 'access_token_value', '0Uv000000000001CAA'


### PR DESCRIPTION
https://developer.salesforce.com/docs/marketing/pardot/guide/getting-started.html#our-first-get-request
>Environment URL: In the example, we use pi.pardot.com, but you use the URL that matches your environment type. Demos, developer orgs, and sandbox environments are hosted on the domain pi.demo.pardot.com. Training and production environments are hosted on the domain pi.pardot.com.

Make domains configurable for sandbox environments
