### PR TITLE
Adding rake for release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       multi_xml (>= 0.5.2)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
+    rake (13.3.1)
     rexml (3.4.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -40,6 +41,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 1.10)
   fakeweb (= 1.3.0)
+  rake (~> 13.0)
   rspec (= 3.5.0)
   ruby-pardot!
 

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 1.10"
   s.add_development_dependency "rspec", "3.5.0"
   s.add_development_dependency "fakeweb", "1.3.0"
+  s.add_development_dependency "rake", "~> 13.0"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map { |f| f =~ %r{^bin/(.*)} ? Regexp.last_match(1) : nil }.compact


### PR DESCRIPTION
To run `bundle exec rake release` to push the new gem, I need rake as a dev dependency.

To test:
- Run `gem install`
- Run `bundle exec rake build`: verifies the build, but does not push to RubyGems or Github.